### PR TITLE
fix: /bot-stop 是空操作，无法中止生成

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,7 +27,7 @@ export function buildCommandList(deps: CommandDeps): SlashCommand[] {
     // 杂项
     pingCommand(),
     versionCommand(deps),
-    stopCommand(),
+    stopCommand(deps),
   ];
 
   // help 需要访问完整列表（含自身），通过闭包惰性引用

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -3,6 +3,7 @@
  */
 import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
 import type { CommandDeps } from './types.js';
+import { getScopePeer } from '../shared/index.js';
 
 /** /bot-ping — 连通性测试 */
 export function pingCommand(): SlashCommand {
@@ -27,11 +28,20 @@ export function versionCommand({ manager }: CommandDeps): SlashCommand {
 }
 
 /** /bot-stop — 中止当前生成（隐藏） */
-export function stopCommand(): SlashCommand {
+export function stopCommand({ manager }: CommandDeps): SlashCommand {
   return {
     name: 'bot-stop',
     description: '中止当前生成',
     hidden: true,
-    handler: () => ({ kind: 'noop' as const }),
+    handler: (cmdCtx) => {
+      const { scope, peerId } = getScopePeer(cmdCtx);
+      const record = manager.getSessionRecord(scope, peerId);
+      if (record === undefined) return '当前没有进行中的生成';
+
+      // cancel 会让当前轮以 turn/end (kind=interrupted) 收尾，
+      // 出站侧据此 flush 已生成的文本并关闭流式会话。
+      record.agent.cancel({ kind: 'user' });
+      return '已中止 ⛔';
+    },
   };
 }

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -30,13 +30,16 @@ export function versionCommand({ manager }: CommandDeps): SlashCommand {
 /** /bot-stop — 中止当前生成（隐藏） */
 export function stopCommand({ manager }: CommandDeps): SlashCommand {
   return {
-    name: 'bot-stop',
+    name: 'stop',
     description: '中止当前生成',
     hidden: true,
     handler: (cmdCtx) => {
       const { scope, peerId } = getScopePeer(cmdCtx);
       const record = manager.getSessionRecord(scope, peerId);
-      if (record === undefined) return '当前没有进行中的生成';
+      // 会话存在不等于正在生成：只有 agent 处于 running 才算有进行中的回复
+      if (record === undefined || record.agent.status !== 'running') {
+        return '当前没有进行中的生成';
+      }
 
       // cancel 会让当前轮以 turn/end (kind=interrupted) 收尾，
       // 出站侧据此 flush 已生成的文本并关闭流式会话。

--- a/src/gateway/middleware-setup.ts
+++ b/src/gateway/middleware-setup.ts
@@ -4,7 +4,7 @@
  * 根据插件配置组装 SDK 内置中间件链（洋葱模型）。
  * 中间件负责过滤与上下文富化；最终消息统一由 bot.on('message') 处理转发。
  */
-import type { QQBot, MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
+import type { QQBot } from '@tencent-connect/qqbot-nodejs';
 import {
   errorHandler,
   messageFilter,
@@ -89,13 +89,14 @@ export function setupMiddlewares(
   bot.use(slash.middleware);
 
   // 9. 并发串行 + 消息合并（同 peer 排队，避免 session 冲突）
+  //
+  // 这里不配 urgentPredicate：斜杠命令在上一层就被 slashCommand 短路了
+  // （命中即 ctx.stop），永远走不到本中间件，判定 /bot-stop 的谓词不会被调用。
+  // /bot-stop 的中止改由命令 handler 直接调 agent.cancel 完成。
   bot.use(concurrencyGuard({
     strategy: 'merge',
     maxQueue: config.maxQueue,
     maxProcessingMs: config.processingTimeoutMs,
-    urgentPredicate: (mCtx: MiddlewareContext) => {
-      return (mCtx.message.content ?? '').trim() === '/bot-stop';
-    },
   }));
 
   // 10. C2C 输入状态指示

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -23,6 +23,8 @@ export interface SessionEventLike {
 export interface DshAgent {
   readonly id: string;
   readonly ctx: Context;
+  /** 当前生命周期状态（对齐 dsh Agent.status，用于判断是否正在生成） */
+  readonly status: 'idle' | 'running';
   /** 底层 session（fork 时作为 source，events 用于统计/导出） */
   readonly session: {
     readonly id: string;


### PR DESCRIPTION
## 现象

生成过程中发送 `/bot-stop`，没有任何反应——既不会中止当前轮，也不会有任何回复。

## 根因

两处叠加：

1. `commands/misc.ts` 里 `stopCommand` 的 handler 直接返回 `{ kind: 'noop' }`，本身不做任何事。
2. 真正的中止意图寄托在 `gateway/middleware-setup.ts` 里 `concurrencyGuard` 的 `urgentPredicate`（判定 `content === '/bot-stop'`），但它**永远不会被调用**：`slashCommand` 排在 `concurrencyGuard` 之前，而 SDK 的 slash-command 中间件对每个命中的命令都会 `ctx.stop()` 短路整条链（`// Commands always short-circuit the chain.`），`/bot-stop` 这条消息根本走不到 guard。

即便它能走到，urgent 分支做的也只是「清空 merge 缓冲 + 插队执行 next()」，并不会取消正在进行的生成。

## 改动

让 handler 直接取本 peer 的会话记录并调用 `agent.cancel({ kind: 'user' })`——这与 `SessionManager.remove()` 和闲置回收里已有的用法一致。

安全性：被取消的轮次会以 `turn/end (kind=interrupted)` 收尾，因此

- `OutboundRouter.onTurnEnd` 会正常 flush 已生成的文本、关闭流式会话，不会留下悬挂的流；
- `extractTurnError` 只在 `reason.kind === 'error'` 时返回错误，所以用户主动中止不会被误报成「⚠️ 本轮异常结束」。

同时删掉了那个走不到的 `urgentPredicate`（以及只为它引入的 `MiddlewareContext` 类型导入），避免让 guard 看起来提供了一条实际不存在的优先通道。

## 验证

`pnpm exec tsc --noEmit` 通过；`pnpm test` 14 个用例全部通过。

## 另外

`hidden: true` 我没有改动。不过这个命令现在是真正可用的了，是否要在 `/bot-help` 里放出来，交给维护者判断。