### PR TITLE
feat: rename commands and add /compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 
 | 命令 | 说明 |
 |------|------|
-| `/bot-reset` | 重置当前会话（清除上下文） |
-| `/bot-model` | 查看或切换模型 |
+| `/new`（别名 `/reset` `/clear`） | 开始新会话（清空上下文） |
+| `/compact` | 压缩会话历史（摘要替换旧记录，保留上下文） |
+| `/model` | 查看或切换模型 |
+| `/stop` | 中止当前生成 |
+| `/bot-ping` | 连通性测试 |
+| `/bot-version` | 查看版本信息 |
 | `/bot-status` | 查看当前会话状态 |
 | `/bot-help` | 查看所有指令 |
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -74,8 +74,12 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 
 | Command | Description |
 |------|------|
-| `/bot-reset` | Reset the current session (clear context) |
-| `/bot-model` | View or switch model |
+| `/new` (aliases `/reset` `/clear`) | Start a new session (clear context) |
+| `/compact` | Compact session history (replace old records with a summary) |
+| `/model` | View or switch model |
+| `/stop` | Abort the current generation |
+| `/bot-ping` | Connectivity test |
+| `/bot-version` | View version info |
 | `/bot-status` | View current session status |
 | `/bot-help` | View all commands |
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,28 +1,48 @@
 /**
- * /bot-help — 查看所有指令以及用途
+ * /bot-help — 查看所有指令，按「通用能力 / QQBot 特有」分组展示
  *
- * 参考 openclaw-qqbot 的 bot-help.ts：遍历所有非隐藏命令，
- * 用 <qqbot-cmd-input> 展示为可点击按钮，以 Markdown 格式发送。
+ * 通用能力：对应底层 dsh agent 能力（new/compact/model/stop），无前缀
+ * QQBot 特有：插件自身封装（bot-ping/bot-version/bot-status/bot-help），带 bot- 前缀
  */
-import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { CommandDeps } from './types.js';
-import { sendMarkdownChunked } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.js';
+import { sendMarkdownChunked, PLUGIN_VERSION } from '../shared/index.js';
 
-/** /bot-help — 查看所有指令以及用途 */
-export function helpCommand({ config }: CommandDeps, allCommands: () => SlashCommand[]): SlashCommand {
+/** /bot-help — 分组查看所有指令 */
+export function helpCommand(
+  { config }: CommandDeps,
+  allCommands: () => CategorizedCommand[],
+): CategorizedCommand {
   return {
     name: 'bot-help',
-    description: '查看所有指令以及用途',
+    category: 'qqbot',
+    description: '查看所有指令',
     handler: async (cmdCtx) => {
-      const lines = ['### QQBot插件内置指令', ''];
-
+      const agentCmds: CategorizedCommand[] = [];
+      const qqbotCmds: CategorizedCommand[] = [];
       for (const cmd of allCommands()) {
-        const name = Array.isArray(cmd.name) ? cmd.name[0] : cmd.name;
         if (cmd.hidden) continue;
-        lines.push(`<qqbot-cmd-input text="/${name}" show="/${name}"/> ${cmd.description ?? ''}`);
+        (cmd.category === 'agent' ? agentCmds : qqbotCmds).push(cmd);
       }
 
-      lines.push('', '> dsh-qqbot v0.1.0');
+      const render = (cmds: CategorizedCommand[]): string[] => {
+        const out: string[] = [];
+        for (const cmd of cmds) {
+          const name = Array.isArray(cmd.name) ? cmd.name[0] : cmd.name;
+          out.push(`<qqbot-cmd-input text="/${name}" show="/${name}"/> ${cmd.description ?? ''}`);
+        }
+        return out;
+      };
+
+      const lines: string[] = ['### 🤖 QQBot 指令', ''];
+
+      if (agentCmds.length > 0) {
+        lines.push('**通用能力**', '', ...render(agentCmds), '');
+      }
+      if (qqbotCmds.length > 0) {
+        lines.push('**插件内置指令**', '', ...render(qqbotCmds), '');
+      }
+
+      lines.push('', `> dsh-qqbot v${PLUGIN_VERSION}`);
       await sendMarkdownChunked(cmdCtx, lines.join('\n'), config.textChunkLimit);
       return { kind: 'noop' as const };
     },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,10 +3,13 @@
  *
  * 每个命令拆分为独立文件，此处仅编排。参考 openclaw-qqbot 的
  * commands/index.ts 模式：工厂函数注入依赖，统一导出命令列表。
+ *
+ * 命令按 category 分两类：
+ *   - agent：底层 dsh agent 通用能力（new/compact/model/stop）
+ *   - qqbot：插件自身特有（ping/version/status/help）
  */
-import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { CommandDeps } from './types.js';
-import { resetCommand, newCommand } from './session.js';
+import type { CommandDeps, CategorizedCommand } from './types.js';
+import { newCommand, compactCommand } from './session.js';
 import { modelCommand } from './model.js';
 import { statusCommand } from './status.js';
 import { helpCommand } from './help.js';
@@ -15,19 +18,17 @@ import { pingCommand, versionCommand, stopCommand } from './misc.js';
 /**
  * 构建标准命令列表
  */
-export function buildCommandList(deps: CommandDeps): SlashCommand[] {
-  const commands: SlashCommand[] = [
-    // 会话
-    resetCommand(deps),
+export function buildCommandList(deps: CommandDeps): CategorizedCommand[] {
+  const commands: CategorizedCommand[] = [
+    // 通用能力（底层 agent）
     newCommand(deps),
-    // 模型
+    compactCommand(deps),
     modelCommand(deps),
-    // 状态
-    statusCommand(deps),
-    // 杂项
+    stopCommand(deps),
+    // QQBot 特有
     pingCommand(),
     versionCommand(deps),
-    stopCommand(deps),
+    statusCommand(deps),
   ];
 
   // help 需要访问完整列表（含自身），通过闭包惰性引用

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -1,36 +1,41 @@
 /**
- * 杂项命令：/ping /version /stop
+ * 杂项命令
+ *
+ * - /bot-ping /bot-version：QQBot 插件特有（连通性测试、版本信息）
+ * - /stop：中止当前生成（对应底层 agent cancel，通用能力）
  */
-import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { CommandDeps } from './types.js';
-import { getScopePeer } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.js';
+import { getScopePeer, PLUGIN_VERSION } from '../shared/index.js';
 
 /** /bot-ping — 连通性测试 */
-export function pingCommand(): SlashCommand {
+export function pingCommand(): CategorizedCommand {
   return {
     name: 'bot-ping',
+    category: 'qqbot',
     description: '连通性测试',
     handler: () => 'pong 🏓',
   };
 }
 
 /** /bot-version — 查看版本信息 */
-export function versionCommand({ manager }: CommandDeps): SlashCommand {
+export function versionCommand({ manager }: CommandDeps): CategorizedCommand {
   return {
     name: 'bot-version',
+    category: 'qqbot',
     description: '查看版本信息',
     handler: () => {
       const current = manager.getEffectiveModel('c2c', '');
       const modelInfo = current ? `${current.provider}/${current.model}` : '宿主默认';
-      return `dsh-qqbot v0.1.0 | model: ${modelInfo}`;
+      return `dsh-qqbot v${PLUGIN_VERSION} | model: ${modelInfo}`;
     },
   };
 }
 
-/** /bot-stop — 中止当前生成（隐藏） */
-export function stopCommand({ manager }: CommandDeps): SlashCommand {
+/** /stop — 中止当前生成（隐藏） */
+export function stopCommand({ manager }: CommandDeps): CategorizedCommand {
   return {
     name: 'stop',
+    category: 'agent',
     description: '中止当前生成',
     hidden: true,
     handler: (cmdCtx) => {

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -1,14 +1,14 @@
 /**
- * 模型命令：/bot-model — 查看或切换模型
+ * 模型命令：/model — 查看或切换模型
  */
-import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { CommandDeps } from './types.js';
+import type { CommandDeps, CategorizedCommand } from './types.js';
 import { getScopePeer, sendMarkdownChunked } from '../shared/index.js';
 
-export function modelCommand({ manager, config }: CommandDeps): SlashCommand {
+export function modelCommand({ manager, config }: CommandDeps): CategorizedCommand {
   return {
-    name: 'bot-model',
-    description: '查看或切换模型（用法: /bot-model [provider/model]）',
+    name: 'model',
+    category: 'agent',
+    description: '查看或切换模型（用法: /model [provider/model]）',
     handler: async (cmdCtx) => {
       const { scope, peerId } = getScopePeer(cmdCtx);
       const args = (cmdCtx.command?.raw ?? '').trim();
@@ -16,7 +16,7 @@ export function modelCommand({ manager, config }: CommandDeps): SlashCommand {
       // 无参数：显示当前模型 + 可用模型列表（可点击）
       if (!args) {
         const current = manager.getEffectiveModel(scope, peerId);
-        const models = manager.listAvailableModels();
+        const models = await manager.listAvailableModels();
 
         // 当前模型展示：优先用别名（name），找不到别名时回退到 provider/model id
         let currentDisplay = '宿主默认配置';
@@ -36,11 +36,11 @@ export function modelCommand({ manager, config }: CommandDeps): SlashCommand {
           for (const m of models) {
             const modelPath = `${m.provider}/${m.id}`;
             const displayName = m.name ? `${m.name}` : modelPath;
-            lines.push(`<qqbot-cmd-input text="/bot-model ${modelPath}" show="/bot-model ${displayName}"/>`);
+            lines.push(`<qqbot-cmd-input text="/model ${modelPath}" show="/model ${displayName}"/>`);
           }
         }
 
-        lines.push('', '手动指定: `/bot-model provider/model`');
+        lines.push('', '手动指定: `/model provider/model`');
 
         await sendMarkdownChunked(cmdCtx, lines.join('\n'), config.textChunkLimit);
         return { kind: 'noop' as const };
@@ -62,7 +62,7 @@ export function modelCommand({ manager, config }: CommandDeps): SlashCommand {
       }
 
       if (!provider || !model) {
-        return '用法: /bot-model provider/model\n示例: /bot-model deepseek-official/deepseek-v4-flash';
+        return '用法: /model provider/model\n示例: /model deepseek-official/deepseek-v4-flash';
       }
 
       await manager.setModelOverride(scope, peerId, { provider, model });

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -1,32 +1,53 @@
 /**
- * 会话相关命令：/bot-reset /bot-clear /bot-new
+ * 会话相关命令
+ *
+ * - /new（别名 /reset /clear）：开始新会话（换新 sessionId）
+ * - /compact：原地压缩会话历史（保留 sessionId，摘要替换旧历史）
+ *
+ * 两者都对应底层 dsh agent 能力，分类为 agent（通用能力）。
  */
-import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { CommandDeps } from './types.js';
+import type { CommandDeps, CategorizedCommand } from './types.js';
 import { getScopePeer } from '../shared/index.js';
 
-/** /bot-reset /bot-clear — 重置当前会话 */
-export function resetCommand({ manager }: CommandDeps): SlashCommand {
+/** /new（别名 /reset /clear）— 开始新会话 */
+export function newCommand({ manager }: CommandDeps): CategorizedCommand {
   return {
-    name: ['bot-reset', 'bot-clear'],
-    description: '重置当前会话（清除上下文）',
-    handler: (cmdCtx) => {
-      const { scope, peerId } = getScopePeer(cmdCtx);
-      void manager.remove(scope, peerId);
-      return '会话已重置 ✓';
-    },
-  };
-}
-
-/** /bot-new — 开始新会话 */
-export function newCommand({ manager }: CommandDeps): SlashCommand {
-  return {
-    name: 'bot-new',
+    name: ['new', 'reset', 'clear'],
+    category: 'agent',
     description: '开始新会话（清空上下文）',
     handler: (cmdCtx) => {
       const { scope, peerId } = getScopePeer(cmdCtx);
       void manager.remove(scope, peerId);
       return '已开启新会话 ✓';
+    },
+  };
+}
+
+/** /compact — 原地压缩会话历史 */
+export function compactCommand({ manager }: CommandDeps): CategorizedCommand {
+  return {
+    name: 'compact',
+    category: 'agent',
+    description: '压缩会话历史（摘要替换旧记录，保留上下文）',
+    handler: async (cmdCtx) => {
+      const { scope, peerId } = getScopePeer(cmdCtx);
+      const outcome = await manager.compact(scope, peerId);
+
+      if (outcome.ok) {
+        if (!outcome.shadowed) return '没有可压缩的历史';
+        return `✅ 已压缩 ${outcome.shadowed} 条历史记录（约 ${outcome.tokens ?? 0} tokens）`;
+      }
+
+      switch (outcome.reason) {
+        case 'no-session':
+          return '当前无活跃会话';
+        case 'busy':
+          return '正在生成中，无法压缩';
+        case 'unavailable':
+          return '压缩能力不可用（当前会话的 agent preset 未加载 compaction 服务）';
+        default:
+          return `压缩失败: ${outcome.message ?? '未知错误'}`;
+      }
     },
   };
 }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,14 +1,14 @@
 /**
- * 状态命令：/bot-status
+ * 状态命令：/bot-status（QQBot 特有）
  */
-import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { CommandDeps } from './types.js';
+import type { CommandDeps, CategorizedCommand } from './types.js';
 import { getScopePeer, formatRelativeTime } from '../shared/index.js';
 
 /** /bot-status — 查看当前会话状态 */
-export function statusCommand({ manager }: CommandDeps): SlashCommand {
+export function statusCommand({ manager }: CommandDeps): CategorizedCommand {
   return {
     name: 'bot-status',
+    category: 'qqbot',
     description: '查看当前会话状态',
     handler: (cmdCtx) => {
       const { scope, peerId } = getScopePeer(cmdCtx);

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -3,10 +3,19 @@
  *
  * 每个命令工厂函数接收 CommandDeps，由 commands/index.ts 统一注入。
  */
+import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
 import type { SessionManager } from '../session/index.js';
 import type { ImQQBotConfig } from '../config.js';
 
 export interface CommandDeps {
   manager: SessionManager;
   config: ImQQBotConfig;
+}
+
+/** 命令分类：agent = 底层 agent 通用能力，qqbot = 插件特有 */
+export type CommandCategory = 'agent' | 'qqbot';
+
+/** 带分类的斜杠命令（category 供 help 分组展示，SDK 忽略未知字段） */
+export interface CategorizedCommand extends SlashCommand {
+  category: CommandCategory;
 }

--- a/src/gateway/middleware-setup.ts
+++ b/src/gateway/middleware-setup.ts
@@ -83,16 +83,14 @@ export function setupMiddlewares(
 
   // 8. 斜杠命令（在 concurrencyGuard 之前，命令匹配后不排队直接响应）
   const slash = slashCommand({
-    autoHelp: true,
+    // 关闭 autoHelp：help 命令由 qqbot 注册为 /bot-help，
+    // 避免 SDK 再自动注册一个无前缀的 /help 造成重复
+    autoHelp: false,
     commands: buildCommandList({ manager, config }),
   });
   bot.use(slash.middleware);
 
   // 9. 并发串行 + 消息合并（同 peer 排队，避免 session 冲突）
-  //
-  // 这里不配 urgentPredicate：斜杠命令在上一层就被 slashCommand 短路了
-  // （命中即 ctx.stop），永远走不到本中间件，判定 /bot-stop 的谓词不会被调用。
-  // /bot-stop 的中止改由命令 handler 直接调 agent.cancel 完成。
   bot.use(concurrencyGuard({
     strategy: 'merge',
     maxQueue: config.maxQueue,

--- a/src/model/model-resolver.ts
+++ b/src/model/model-resolver.ts
@@ -19,6 +19,12 @@ import type { ModelRoute, ModelEntry } from './types.js';
 import { PrefsStore } from './prefs-store.js';
 import { SettingsReader } from './settings-reader.js';
 
+/** ctx.llm 服务的最小接口（listProviders 同步，listModels 异步） */
+interface LlmServiceLike {
+  listProviders(): Array<{ id: string; name: string }> | string[];
+  listModels(providerId: string): Promise<readonly { id: string; name?: string }[]>;
+}
+
 export class ModelResolver {
   private readonly prefs: PrefsStore;
   private readonly settings: SettingsReader;
@@ -130,8 +136,38 @@ export class ModelResolver {
 
   /**
    * 列出所有可用模型
+   *
+   * 优先走 ctx.llm 服务动态发现（对齐 webui 的 buildModelCatalog），
+   * 服务不可用或失败时回退 settings.yaml 静态配置。
    */
-  listModels(): ModelEntry[] {
+  async listModels(): Promise<ModelEntry[]> {
+    const llm = this.getLlmService();
+    if (!llm) return this.settings.readModels();
+
+    try {
+      const providers = llm.listProviders();
+      const entries: ModelEntry[] = [];
+      for (const provider of providers) {
+        const providerId = typeof provider === 'string' ? provider : provider.id;
+        try {
+          const models = await llm.listModels(providerId);
+          for (const model of models) {
+            entries.push({ provider: providerId, id: model.id, name: model.name });
+          }
+        } catch (err) {
+          // 单个 provider 失败，跳过（对齐 webui 的 failures 语义）
+          this.logger?.debug(
+            `ModelResolver: provider ${providerId} 模型列表获取失败: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      if (entries.length > 0) return entries;
+    } catch (err) {
+      this.logger?.warn(
+        `ModelResolver: 动态发现模型失败，回退 settings.yaml: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
     return this.settings.readModels();
   }
 
@@ -139,21 +175,14 @@ export class ModelResolver {
    * 列出可用 provider 名称
    */
   listProviders(): string[] {
-    try {
-      const llm = this.getService('llm') as
-        | { listProviders(): Array<{ id: string; name: string }> | string[] }
-        | undefined;
-
-      if (llm && typeof llm.listProviders === 'function') {
-        const providers = llm.listProviders();
-        if (providers.length > 0) {
-          const first = providers[0];
-          if (typeof first === 'string') return providers as string[];
-          return (providers as Array<{ id: string; name: string }>).map((p) => p.id);
-        }
+    const llm = this.getLlmService();
+    if (llm) {
+      const providers = llm.listProviders();
+      if (providers.length > 0) {
+        const first = providers[0];
+        if (typeof first === 'string') return providers as string[];
+        return (providers as Array<{ id: string; name: string }>).map((p) => p.id);
       }
-    } catch {
-      // 忽略
     }
 
     return this.settings.readProviders();
@@ -181,10 +210,28 @@ export class ModelResolver {
     return undefined;
   }
 
-  /** 统一的 Cordis 服务访问 */
+  /** 统一的 Cordis 服务访问（可选获取：服务未注入时静默返回 undefined，避免 Proxy 抛错） */
   private getService(name: string): unknown {
-    const ctxAny = this.ctx as unknown as Record<string, unknown>;
-    return ctxAny[name] ??
-      (typeof ctxAny.get === 'function' ? (ctxAny.get as (key: string) => unknown)(name) : undefined);
+    try {
+      const ctxAny = this.ctx as unknown as { get?: (key: string) => unknown };
+      return typeof ctxAny.get === 'function' ? ctxAny.get(name) : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** 获取 ctx.llm 服务（最小接口收窄，不可用时返回 undefined） */
+  private getLlmService(): LlmServiceLike | undefined {
+    try {
+      const llm = this.getService('llm') as LlmServiceLike | undefined;
+      if (llm && typeof llm.listProviders === 'function' && typeof llm.listModels === 'function') {
+        return llm;
+      }
+    } catch (err) {
+      this.logger?.warn(
+        `ModelResolver: ctx.llm 服务访问失败: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return undefined;
   }
 }

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -31,7 +31,18 @@ import type {
   SessionRecord,
   SessionStatus,
   TokenUsageStats,
+  CompactionServiceLike,
+  CompactOutcome,
 } from './types.js';
+
+/** ManualCompactionError 各 code 的友好提示（对齐 command-compact 的 expectedFailure 语义） */
+const COMPACTION_ERROR_HINTS: Record<string, string> = {
+  busy: '压缩服务忙，请稍后重试',
+  cancelled: '压缩已取消',
+  changed: '历史在压缩过程中发生变化，请重试',
+  commit: '压缩提交失败',
+  persistence: '压缩完成但保存失败',
+};
 
 export class SessionManager {
   private sessions = new Map<string, SessionRecord>();
@@ -144,7 +155,7 @@ export class SessionManager {
     this.modelResolver.clearSessionId(key);
   }
 
-  listAvailableModels(): ModelEntry[] {
+  async listAvailableModels(): Promise<ModelEntry[]> {
     return this.modelResolver.listModels();
   }
 
@@ -360,12 +371,62 @@ export class SessionManager {
   async remove(scope: ChatScope, peerId: string): Promise<void> {
     const key = this.sessionKey(scope, peerId);
     const record = this.sessions.get(key);
+    this.modelResolver.setSessionId(key, randomUUID());
+
     if (!record) return;
     this.sessions.delete(key);
-    this.modelResolver.clearSessionId(key);
     record.agent.cancel({ kind: 'user' });
     await record.handle.dispose().catch(() => {});
     this.logger.info(`session removed: key=${key}`);
+  }
+
+  /**
+   * 原地压缩当前会话历史（保留 sessionId，用摘要替换旧历史）。
+   *
+   * 需通过 agentPresets.serviceFor(agent, 'compaction') 解析；未挂载时优雅降级。
+   * 这是「压缩上下文」的语义，区别于 remove() 的「换新会话」。
+   */
+  async compact(scope: ChatScope, peerId: string): Promise<CompactOutcome> {
+    const key = this.sessionKey(scope, peerId);
+    const record = this.sessions.get(key);
+    if (!record) return { ok: false, reason: 'no-session' };
+    if (record.agent.status !== 'idle') return { ok: false, reason: 'busy' };
+
+    let compaction: CompactionServiceLike | undefined;
+    try {
+      const presets = this.ctx.get('agentPresets') as AgentPresetsLike | undefined;
+      compaction = (presets?.serviceFor(record.agent, 'compaction') ?? this.ctx.get('compaction')) as CompactionServiceLike | undefined;
+    } catch {
+      compaction = undefined;
+    }
+    if (!compaction) return { ok: false, reason: 'unavailable' };
+
+    const route = this.modelResolver.getEffectiveRoute(key);
+    const agentCtx = {
+      session: record.agent.session,
+      options: { provider: route?.provider, model: route?.model },
+      runMaintenance: record.agent.runMaintenance.bind(record.agent),
+    };
+
+    try {
+      const result = await compaction.compactNow(agentCtx, new AbortController().signal);
+      if (result === null) return { ok: true, shadowed: 0, tokens: 0 };
+      return { ok: true, shadowed: result.shadowedSeqs.length, tokens: result.shadowedTokenCount };
+    } catch (err) {
+      const code = (err as { code?: string } | null)?.code;
+      // summary = 摘要没有更小 = 历史不足以压缩，属正常结果而非失败
+      if (code === 'summary') {
+        return { ok: true, shadowed: 0, tokens: 0 };
+      }
+      // 其他 ManualCompactionError 预期失败，给友好文案（debug 记录，不 warn 刷屏）
+      if (code !== undefined && code in COMPACTION_ERROR_HINTS) {
+        this.logger.debug(`compact declined: key=${key} code=${code}`);
+        return { ok: false, reason: 'failed', message: COMPACTION_ERROR_HINTS[code] };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`compact failed: key=${key} err=${message}`);
+      return { ok: false, reason: 'failed', message };
+    }
   }
 
   async disposeAll(): Promise<void> {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -33,6 +33,32 @@ export interface DshAgent {
   cancel(cause: { kind: string }): void;
   followup(message: unknown): void;
   whenIdle(): Promise<void>;
+  /** 运行一个非 turn 维护任务（compact 等需要 idle 时串行执行的操作） */
+  runMaintenance<T>(task: (signal: AbortSignal) => Promise<T>): Promise<T>;
+}
+
+/** compactNow 返回结果的精简视图（只取展示所需字段） */
+export interface CompactionResultLike {
+  shadowedSeqs: readonly number[];
+  shadowedTokenCount: number;
+}
+
+/** ctx.compaction 服务的最小接口（compactNow 依赖，可选注入） */
+export interface CompactionServiceLike {
+  compactNow(
+    agent: unknown,
+    signal: AbortSignal,
+    sourceCommandId?: string,
+  ): Promise<CompactionResultLike | null>;
+}
+
+/** compact 操作结果 */
+export interface CompactOutcome {
+  ok: boolean;
+  reason?: 'no-session' | 'busy' | 'unavailable' | 'failed';
+  shadowed?: number;
+  tokens?: number;
+  message?: string;
 }
 
 export interface DshAgentHandle {
@@ -69,6 +95,8 @@ export interface AgentPresetsLike {
   readonly defaultId: string;
   resolve(id?: string): Promise<{ id: string }>;
   mount(agentCtx: Context, id?: string): Promise<unknown>;
+  /** 从 agent 的 preset scope 解析隔离服务（如 compaction），未挂载返回 undefined */
+  serviceFor(agent: { ctx: Context }, name: string): unknown | undefined;
 }
 
 /** preset 组合结果 */

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,6 +1,6 @@
 /**
  * 共享工具层
  */
-export { getProfileDir, resolveEnv, formatRelativeTime, buildUserAgent } from './utils.js';
+export { getProfileDir, resolveEnv, formatRelativeTime, buildUserAgent, PLUGIN_VERSION } from './utils.js';
 export { getScopePeer } from './scope.js';
 export { sendMarkdownChunked } from './send-helper.js';

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -12,8 +12,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PLUGIN_ROOT = resolve(__dirname, '../..');
 
-/** 插件版本号（从 package.json 读取） */
-const PLUGIN_VERSION = readPluginVersion();
+/** 插件版本号（从 package.json 读取，供 help/version 等展示真实版本） */
+export const PLUGIN_VERSION = readPluginVersion();
 
 function readPluginVersion(): string {
   try {


### PR DESCRIPTION
## Summary

Refactor the slash-command system: split commands into "agent capabilities" vs. "QQBot-specific" categories, rename commands consistently, and add the `/compact` session-compaction capability.

## Changes

### 1. Command categorization & renaming

Commands are now grouped into two categories, displayed by `/bot-help`:

| Category | Description | Commands |
|----------|-------------|----------|
| `agent` | Underlying dsh agent capabilities (no prefix) | `/new` (aliases `/reset` `/clear`), `/compact`, `/model`, `/stop` |
| `qqbot` | Plugin-specific (`bot-` prefix) | `/bot-ping`, `/bot-version`, `/bot-status`, `/bot-help` |

Renames:

- `/bot-reset` `/bot-clear` `/bot-new` → `/new` (aliases `/reset` `/clear`)
- `/bot-model` → `/model`
- `/bot-stop` → `/stop`

Added `CommandCategory` type and `CategorizedCommand` interface (the SDK ignores the unknown `category` field). Also disabled SDK `autoHelp` to avoid a duplicate prefix-less `/help` registration.

### 2. New `/compact` command

- Compacts session history in place: keeps the `sessionId`, replacing old records with a summary to save context.
- Runs via `runMaintenance` serially while the agent is idle, avoiding conflicts with in-flight turns.
- Added `CompactionResultLike` / `CompactionServiceLike` / `CompactOutcome` interfaces.
- Prefers the `ctx.compaction` service; returns a friendly message when the summary is not smaller (history too short) or otherwise unavailable.

### 3. Dynamic model discovery

- `ModelResolver.listModels()` is now async and prefers dynamic discovery through the `ctx.llm` service (aligning with the webui `buildModelCatalog`).
- Falls back to the static `settings.yaml` config when the service is unavailable or a single provider fails.

### 4. Documentation

- Updated the command tables in `README.md` and `README_EN.md`.
