### PR TITLE
feat(transport): QQ markdown 方言降级（表格/图片/长代码）+ 超长行切分修复

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,14 +51,13 @@
       }
     },
     "node_modules/.pnpm/@deepseek-ai+cordis@4.0.1": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/@deepseek-ai+cordis@4.0.1/node_modules/@deepseek-ai/cordis": {
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2",
         "@standard-schema/spec": "^1.1.0"
@@ -89,9 +88,7 @@
       "license": "MIT"
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-agent@0.1.0-rc.6_b0514d7a320728b6d8f5a31eb3960e10": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-agent@0.1.0-rc.6_b0514d7a320728b6d8f5a31eb3960e10/node_modules/@deepseek-ai/cordis": {
       "resolved": "node_modules/.pnpm/@deepseek-ai+cordis@4.0.1/node_modules/@deepseek-ai/cordis",
@@ -129,7 +126,6 @@
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-attachment@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-brand_5463d1d16dfeb8cbf43fe361fb2eba74": {
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-attachment@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-brand_5463d1d16dfeb8cbf43fe361fb2eba74/node_modules/@deepseek-ai/cordis": {
@@ -153,7 +149,6 @@
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-brand@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-invariants_757bf6a984ac37281430ad822ab10469": {
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-brand@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-invariants_757bf6a984ac37281430ad822ab10469/node_modules/@deepseek-ai/cordis": {
@@ -174,9 +169,7 @@
       "extraneous": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-llm@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-attachment@0_4ed4e5c71eb965b0bd6912871e829940": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-llm@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-attachment@0_4ed4e5c71eb965b0bd6912871e829940/node_modules/@deepseek-ai/cordis": {
       "resolved": "node_modules/.pnpm/@deepseek-ai+cordis@4.0.1/node_modules/@deepseek-ai/cordis",
@@ -216,7 +209,6 @@
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-scope@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-invariants_6f3351786c779449c277f079a737f571": {
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-scope@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-invariants_6f3351786c779449c277f079a737f571/node_modules/@deepseek-ai/cordis": {
@@ -234,9 +226,7 @@
       }
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-session@0.1.0-rc.6_6fd26f59436a18b115f326d6060415e6": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-session@0.1.0-rc.6_6fd26f59436a18b115f326d6060415e6/node_modules/@deepseek-ai/cordis": {
       "resolved": "node_modules/.pnpm/@deepseek-ai+cordis@4.0.1/node_modules/@deepseek-ai/cordis",
@@ -269,9 +259,7 @@
       }
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-system-prompt@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-in_ae19c1446da8797d55176bf5f8e2b0ad": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-system-prompt@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-in_ae19c1446da8797d55176bf5f8e2b0ad/node_modules/@deepseek-ai/cordis": {
       "resolved": "node_modules/.pnpm/@deepseek-ai+cordis@4.0.1/node_modules/@deepseek-ai/cordis",
@@ -306,7 +294,6 @@
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-timeout@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-invarian_8c173ab999b05cf1db05d479dd44e888": {
       "dev": true,
-      "optional": true,
       "peer": true
     },
     "node_modules/.pnpm/@deepseek-ai+dsh-timeout@0.1.0-rc.6_@deepseek-ai+cordis@4.0.1_@deepseek-ai+dsh-invarian_8c173ab999b05cf1db05d479dd44e888/node_modules/@deepseek-ai/cordis": {
@@ -327,9 +314,7 @@
       "extraneous": true
     },
     "node_modules/.pnpm/@deepseek-ai+schemastery@3.18.1": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/@deepseek-ai+schemastery@3.18.1/node_modules/@deepseek-ai/cosmokit": {
       "resolved": "node_modules/.pnpm/@deepseek-ai+cosmokit@1.8.2/node_modules/@deepseek-ai/cosmokit",
@@ -339,7 +324,6 @@
       "version": "3.18.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@deepseek-ai/cosmokit": "^1.8.2",
         "@standard-schema/spec": "^1.1.0"
@@ -354,11 +338,7 @@
         "typescript": "^5.6.2"
       }
     },
-    "node_modules/.pnpm/@tencent-connect+qqbot-connector@1.2.0": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "node_modules/.pnpm/@tencent-connect+qqbot-connector@1.2.0": {},
     "node_modules/.pnpm/@tencent-connect+qqbot-connector@1.2.0/node_modules/@tencent-connect/qqbot-connector": {
       "version": "1.2.0",
       "license": "UNLICENSED",
@@ -373,11 +353,7 @@
       "resolved": "node_modules/.pnpm/qrcode-terminal@0.12.0/node_modules/qrcode-terminal",
       "link": true
     },
-    "node_modules/.pnpm/@tencent-connect+qqbot-nodejs@1.0.4": {
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
+    "node_modules/.pnpm/@tencent-connect+qqbot-nodejs@1.0.4": {},
     "node_modules/.pnpm/@tencent-connect+qqbot-nodejs@1.0.4/node_modules/@tencent-connect/qqbot-nodejs": {
       "version": "1.0.4",
       "license": "MIT",
@@ -420,9 +396,7 @@
       }
     },
     "node_modules/.pnpm/typescript@5.9.3": {
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/.pnpm/typescript@5.9.3/node_modules/typescript": {
       "version": "5.9.3",
@@ -683,6 +657,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1367,9 +1342,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,9 +1359,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1407,9 +1376,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1427,9 +1393,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1447,9 +1410,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,9 +1427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1789,6 +1746,7 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2008,6 +1966,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -2542,6 +2501,7 @@
       "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -2601,6 +2561,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3799,9 +3760,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3823,9 +3781,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3847,9 +3802,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3871,9 +3823,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4909,6 +4858,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5433,6 +5383,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5582,6 +5533,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",

--- a/src/transport/chunker.ts
+++ b/src/transport/chunker.ts
@@ -43,6 +43,17 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
   };
 
   const appendLine = (line: string): void => {
+    // 超长单行硬切：单行超过 limit 时按字符切分（QQ 单条消息有字数上限，超长行会被拒）
+    if (line.length > limit) {
+      if (current) {
+        chunks.push(current);
+        current = '';
+      }
+      for (let i = 0; i < line.length; i += limit) {
+        chunks.push(line.slice(i, i + limit));
+      }
+      return;
+    }
     if (!current) {
       current = line;
       return;

--- a/src/transport/md-sanitizer.ts
+++ b/src/transport/md-sanitizer.ts
@@ -1,0 +1,110 @@
+/**
+ * QQ markdown 方言降级器
+ *
+ * QQ 机器人 markdown 消息支持的语法有限（加粗/斜体/链接/行内代码/代码块/引用/列表/标题），
+ * 不支持 GFM 表格与图片。本模块在 sendMarkdown 前把不兼容语法降级为 QQ 可渲染形式：
+ *  - GFM 表格 → 键值列表（`key: value` 逐行）
+ *  - 图片 ![...](url) → 链接文本 [描述](url)（QQ 不支持 markdown 图片）
+ *  - 长代码块截断 + 提示（单消息预算有限）
+ */
+
+/** 表格分隔行（|---|） */
+const TABLE_SEPARATOR = /^\s*\|?[\s:|-]+\|?\s*$/;
+/** 表格数据行 */
+const TABLE_ROW = /^\s*\|(.+)\|\s*$/;
+
+/** 把一行 GFM 表格行解析为单元格数组（去空白、去转义管道符） */
+function splitCells(line: string): string[] {
+  const body = line.trim().replace(/^\||\|$/g, '');
+  return body.split('|').map((c) => c.trim().replace(/\\([|])/g, '$1'));
+}
+
+/**
+ * 降级文本中的 GFM 表格为键值列表。
+ * 逐行扫描：连续表格行（含分隔行）聚合成块 → 表头+首行数据转 `k: v` 键值列表。
+ */
+export function downgradeTables(text: string): string {
+  const lines = text.split('\n');
+  const out: string[] = [];
+  let tableBlock: string[] = [];
+  const flush = () => {
+    if (tableBlock.length === 0) return;
+    const rows = tableBlock.filter((l) => !TABLE_SEPARATOR.test(l)).slice(0, 4);
+    tableBlock = [];
+    if (rows.length === 0) return;
+    const headers = splitCells(rows[0] ?? '');
+    const dataRows = rows.slice(1);
+    if (dataRows.length === 0) {
+      out.push(headers.join(' / '));
+      return;
+    }
+    for (const row of dataRows) {
+      const cells = splitCells(row);
+      const pairs = headers
+        .map((h, i) => `${h}: ${cells[i] ?? ''}`)
+        .filter((p) => !p.endsWith(': '));
+      out.push(pairs.join(' ｜ '));
+    }
+    if (tableBlock.length > 4) {
+      out.push(`…（共 ${tableBlock.length - 1} 行数据，表格已折叠）`);
+    }
+  };
+  for (const line of lines) {
+    if (TABLE_ROW.test(line)) {
+      tableBlock.push(line);
+      continue;
+    }
+    flush();
+    out.push(line);
+  }
+  flush();
+  return out.join('\n');
+}
+
+/** 行内图片 ![...](url) → [描述](url) */
+export function downgradeImages(text: string): string {
+  return text.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, (_m, alt: string, url: string) => `[${alt || '图片'}](${url})`);
+}
+
+/**
+ * 长代码块截断：代码块总长 > maxCodeChars 时截断并附提示。
+ */
+export function truncateLongCodeBlocks(text: string, maxCodeChars = 1200): string {
+  const lines = text.split('\n');
+  const out: string[] = [];
+  let inCode = false;
+  let codeBuf: string[] = [];
+  const flushCode = () => {
+    if (codeBuf.length === 0) return;
+    const joined = codeBuf.join('\n');
+    codeBuf = [];
+    if (joined.length <= maxCodeChars) {
+      out.push(joined);
+      return;
+    }
+    let cut = joined.slice(0, maxCodeChars);
+    const lastNl = cut.lastIndexOf('\n');
+    if (lastNl > maxCodeChars * 0.5) cut = cut.slice(0, lastNl);
+    out.push(`${cut}\n…（代码过长已截断，共 ${joined.length} 字符）`);
+  };
+  for (const line of lines) {
+    if (/^```/.test(line)) {
+      flushCode();
+      inCode = !inCode;
+      out.push(line);
+      continue;
+    }
+    if (inCode) {
+      codeBuf.push(line);
+    } else {
+      out.push(line);
+    }
+  }
+  flushCode();
+  return out.join('\n');
+}
+
+/** 完整降级管线（顺序：表格 → 图片 → 长代码块） */
+export function sanitizeForQQ(text: string): string {
+  return truncateLongCodeBlocks(downgradeImages(downgradeTables(text)));
+}

--- a/src/transport/outbound.ts
+++ b/src/transport/outbound.ts
@@ -8,6 +8,7 @@ import type { SessionManager, SessionRecord } from '../session/index.js';
 import type { ImQQBotConfig } from '../config.js';
 import type { Logger } from '../types.js';
 import { chunkMarkdownText } from './chunker.js';
+import { sanitizeForQQ } from './md-sanitizer.js';
 import { OutboundBuffer, type QQBotSender } from './outbound-buffer.js';
 import { formatToolResult, type ToolsRegistryLike, type ToolResultData } from './tool-presenter.js';
 import {
@@ -165,9 +166,11 @@ class OutboundRouter {
     this.logger.debug(`im-qqbot: turn/end sessionId=${sessionId}`);
   }
 
-  /** 统一发送：切分 + 逐 chunk 发送 + 错误记录 */
+  /** 统一发送：QQ 方言降级 → 切分 → 逐 chunk 发送 + 错误记录 */
   private async send(record: SessionRecord, text: string, tag: string): Promise<void> {
-    const chunks = chunkMarkdownText(text, this.config.textChunkLimit);
+    // QQ markdown 不支持 GFM 表格/图片 → 降级后再切分（见 md-sanitizer.ts）
+    const sanitized = sanitizeForQQ(text);
+    const chunks = chunkMarkdownText(sanitized, this.config.textChunkLimit);
     for (const chunk of chunks) {
       try {
         await this.bot.sendMarkdown(record.replyTarget, chunk);


### PR DESCRIPTION
## 背景
QQ 机器人 markdown 消息不支持 GFM 表格与图片，当前 agent 回复含表格/图片时在 QQ 上渲染异常；单行超长时切分器会整体保留超长行，可能超过 QQ 单消息上限被拒。

## 改动
1. **新增 src/transport/md-sanitizer.ts**：发送前统一降级——
   - GFM 表格 → 键值列表（\key: value\，最多折叠 4 行数据）
   - 行内图片 \![alt](url)\ → 链接文本 \[alt](url)\
   - 长代码块（>1200 字符）截断 + 提示
2. **outbound.ts**：\send()\ 在切分前调用 \sanitizeForQQ()\
3. **chunker.ts**：单行超过 \	extChunkLimit\ 时按字符硬切（修复超长行整体保留导致的超限）

## 验证
- \	sc --noEmit\ 通过
- 单元级验证：表格→键值列表、图片→链接、5000 字符长行→2×4500 分块均符合预期
- 已在本地补丁环境实际运行（QQ 群/私聊富文本回复）