### PR TITLE
chore: add repository metadata and npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @tencent-connect/dsh-qqbot
 
+[![npm version](https://img.shields.io/npm/v/@tencent-connect/dsh-qqbot)](https://www.npmjs.com/package/@tencent-connect/dsh-qqbot)
+
 基于 [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) 的 QQ Bot IM 插件，将 QQ 消息平台作为 dsh agent 的前端协议驱动。
 
 中文 | [English](./README_EN.md)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# @tencent-connect/dsh-qqbot
+<div align="center">
+
+<img width="120" src="https://img.shields.io/badge/🤖-QQ_Bot-blue?style=for-the-badge" alt="QQ Bot" />
+
+**基于 [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) 的 QQ Bot 插件，将 DeepSeek AI 助手接入 QQ 私聊与群聊。**
 
 [![npm version](https://img.shields.io/npm/v/@tencent-connect/dsh-qqbot)](https://www.npmjs.com/package/@tencent-connect/dsh-qqbot)
+[![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/tencent-connect/dsh-qqbot)](https://github.com/tencent-connect/dsh-qqbot)
+[![QQ Bot](https://img.shields.io/badge/QQ_Bot-API_v2-red)](https://bot.q.qq.com/wiki/)
 
-基于 [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) 的 QQ Bot IM 插件，将 QQ 消息平台作为 dsh agent 的前端协议驱动。
+<br/>
 
-中文 | [English](./README_EN.md)
+**[English](./README_EN.md) | 简体中文**
+
+</div>
 
 ## 架构
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,8 +1,19 @@
-# @tencent-connect/dsh-qqbot
+<div align="center">
 
-A QQ Bot IM plugin for [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (dsh), driving the dsh agent loop with the QQ messaging platform as the frontend protocol.
+<img width="120" src="https://img.shields.io/badge/🤖-QQ_Bot-blue?style=for-the-badge" alt="QQ Bot" />
 
-[中文文档](./README.md) | English
+**A QQ Bot plugin for [deepseek-harness](https://github.com/deepseek-ai/deepseek-harness) (dsh), connecting DeepSeek AI assistants to QQ private and group chats.**
+
+[![npm version](https://img.shields.io/npm/v/@tencent-connect/dsh-qqbot)](https://www.npmjs.com/package/@tencent-connect/dsh-qqbot)
+[![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/tencent-connect/dsh-qqbot)](https://github.com/tencent-connect/dsh-qqbot)
+[![QQ Bot](https://img.shields.io/badge/QQ_Bot-API_v2-red)](https://bot.q.qq.com/wiki/)
+
+<br/>
+
+**[简体中文](./README.md) | English**
+
+</div>
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "plugin"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tencent-connect/dsh-qqbot.git"
+  },
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,16 @@
     "plugin"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/tencent-connect/dsh-qqbot.git"
+  },
+  "homepage": "https://github.com/tencent-connect/dsh-qqbot#readme",
+  "bugs": {
+    "url": "https://github.com/tencent-connect/dsh-qqbot/issues"
   },
   "dsh": {
     "bundle": {


### PR DESCRIPTION
## Summary

方便用户从 npm 页面直接打开 GitHub 仓库查看说明。

## Changes

1. **package.json**：新增 `repository` 字段（`https://github.com/tencent-connect/dsh-qqbot.git`）。npm 页面（https://www.npmjs.com/package/@tencent-connect/dsh-qqbot）当前没有 Repository 链接，用户无法从 npm 直达仓库；补齐后 npm 会自动展示 Repository 入口。

2. **README.md**：标题下新增 npm version 徽章（shields.io），链接回 npm 包页面，展示当前发布版本。

## Motivation

用户通过 npm 安装 `@tencent-connect/dsh-qqbot` 后，想查看使用说明/源码时没有从 npm 页面跳转仓库的入口。加上 repository 元数据后，npm 页面即可一键直达 GitHub 仓库看说明。