### PR TITLE
feat(media): add rich media understanding with vision tool

### DIFF
--- a/cordis.yml
+++ b/cordis.yml
@@ -7,6 +7,7 @@
 #   QQBOT_SECRET    - QQ Bot AppSecret
 #   DEEPSEEK_API_KEY - DeepSeek API Key
 #   DSH_CWD         - Agent 工作目录（可选）
+#   HUNYUAN_API_KEY - 视觉模型 API Key（qqbot_describe_image 工具，hunyuan-vision）
 
 # ── 核心 spine ──
 - id: sessions
@@ -24,11 +25,32 @@
 - id: tools
   name: '@deepseek-ai/dsh-tools'
 
+# ── 附件存储（describe_image 工具的 attachments.saveImage 依赖） ──
+- id: attachment-local
+  name: '@deepseek-ai/dsh-attachment-local'
+
 # ── LLM 适配器 ──
 - id: llm-deepseek
   name: '@deepseek-ai/dsh-llm-deepseek'
   config:
     apiKey: ${DEEPSEEK_API_KEY}
+
+# 视觉模型适配器（qqbot_describe_image 工具用 llm.stream 调多模态模型）
+- id: llm-pi-ai
+  name: '@deepseek-ai/dsh-llm-pi-ai'
+  config:
+    providers:
+      hunyuan:
+        displayName: Hunyuan Vision
+        apiKeyEnv: HUNYUAN_API_KEY
+        api: openai-completions
+        baseURL: https://api.hunyuan.cloud.tencent.com/v1
+        defaultInput: [text, image]
+        models:
+          - id: hunyuan-vision
+            name: Hunyuan Vision
+            contextWindow: 32768
+            maxTokens: 4096
 
 # ── 执行能力（按需启用） ──
 - id: tool-bash
@@ -55,15 +77,19 @@
 
 # ── QQ Bot IM 驱动 ──
 - id: im-qqbot
-  name: '@deepseek-ai/dsh-im-qqbot'
+  name: '@tencent-connect/dsh-qqbot'
   config:
     appId: ${QQBOT_APPID}
     appSecret: ${QQBOT_SECRET}
-    transport: websocket
     provider: deepseek
     model: deepseek-chat
     cwd: ${DSH_CWD:-/tmp/dsh-qqbot}
-    requireMention: false
+    requireMention: true
     textChunkLimit: 4500
     sessionIdleTimeout: 1800000
+    showToolResults: false
     debug: false
+    vision:
+      enabled: false
+      provider: ''   # 视觉模型 provider（需与上方 llm-pi-ai 配置的路由一致，如 hunyuan）
+      model: ''      # 视觉模型 id（如 hunyuan-vision）

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,32 @@ export interface AccessControlConfig {
   groupAllow: string[];
 }
 
+export interface MediaConfig {
+  /** 是否启用富媒体理解（图片/视频下载 + 工具分析） */
+  enabled: boolean;
+  /** 富媒体下载大小上限（MB），默认 200 */
+  maxMB: number;
+  /** 富媒体存活时长（小时，TTL），默认 24，0 = 永不过期 */
+  ttlHours: number;
+}
+
+export interface VisionConfig {
+  /** 是否启用视觉理解（qqbot_describe_image 工具） */
+  enabled: boolean;
+  /** 视觉模型 provider（dsh 注册的 llm adapter，如 pi-ai） */
+  provider: string;
+  /** 视觉模型 id（如 qwen-vl-max） */
+  model: string;
+  /** 默认描述 prompt（调用未显式指定时使用） */
+  defaultPrompt: string;
+  /** 图片字节上限，默认 10MB */
+  maxBytes: number;
+  /** 输出 token 上限 */
+  maxTokens: number;
+  /** 视觉调用超时(ms) */
+  timeoutMs: number;
+}
+
 export interface ImQQBotConfig {
   /** QQ Bot AppID */
   appId: string;
@@ -51,6 +77,10 @@ export interface ImQQBotConfig {
   showToolResults: boolean;
   /** 调试模式 */
   debug: boolean;
+  /** 富媒体理解（图片/视频） */
+  media: MediaConfig;
+  /** 视觉理解（qqbot_describe_image 工具，走 dsh llm + attachments） */
+  vision: VisionConfig;
 }
 
 export const ConfigSchema: Schema<ImQQBotConfig> = Schema.object({
@@ -82,4 +112,30 @@ export const ConfigSchema: Schema<ImQQBotConfig> = Schema.object({
   }).description('访问控制'),
   showToolResults: Schema.boolean().default(false).description('是否展示工具调用成功结果（错误始终展示）'),
   debug: Schema.boolean().default(false),
+  media: Schema.object({
+    enabled: Schema.boolean().default(true).description('是否启用富媒体理解（图片/视频下载 + 工具分析）'),
+    maxMB: Schema.number().default(200).description('富媒体下载大小上限(MB)'),
+    ttlHours: Schema.number().default(24).description('富媒体存活时长(小时)，0=永不过期'),
+  }).default({
+    enabled: true,
+    maxMB: 200,
+    ttlHours: 24,
+  }).description('富媒体理解配置'),
+  vision: Schema.object({
+    enabled: Schema.boolean().default(false).description('是否启用视觉理解（qqbot_describe_image 工具）'),
+    provider: Schema.string().default('').description('视觉模型 provider（dsh 注册的 llm adapter，如 pi-ai）'),
+    model: Schema.string().default('').description('视觉模型 id（如 qwen-vl-max）'),
+    defaultPrompt: Schema.string().default('Describe this image in detail.').description('默认描述 prompt'),
+    maxBytes: Schema.number().default(10 * 1024 * 1024).description('图片字节上限'),
+    maxTokens: Schema.number().default(1024).description('输出 token 上限'),
+    timeoutMs: Schema.number().default(120000).description('视觉调用超时(ms)'),
+  }).default({
+    enabled: false,
+    provider: '',
+    model: '',
+    defaultPrompt: 'Describe this image in detail.',
+    maxBytes: 10 * 1024 * 1024,
+    maxTokens: 1024,
+    timeoutMs: 120000,
+  }).description('视觉理解配置'),
 });

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -15,6 +15,8 @@ import { buildUserAgent } from '../shared/index.js';
 import type { ImQQBotConfig } from '../config.js';
 import type { Logger } from '../types.js';
 import { setupMiddlewares } from './middleware-setup.js';
+import { startMediaCleanup } from '../media/media-cleaner.js';
+import { ensureVisionInputModal, registerDescribeImageTool } from '../media/vision-tool.js';
 
 export async function bootstrapGateway(
   ctx: Context,
@@ -81,6 +83,15 @@ export async function bootstrapGateway(
   bot.on('ready', () => {
     console.log(`[im-qqbot] Bot ready! appId=${config.appId}`);
   });
+
+  // ── 富媒体过期清理 ──
+  if (config.media.enabled) {
+    startMediaCleanup(ctx, config.media.ttlHours, logger);
+  }
+
+  // ── 视觉工具注册（qqbot_describe_image，复用 dsh llm + attachments） ──
+  ensureVisionInputModal(config.vision, logger);
+  registerDescribeImageTool(ctx, config.vision, logger);
 
   // ── 生命周期 ──
   (ctx as unknown as { effect(fn: () => (() => Promise<void>) | void, name?: string): void })

--- a/src/media/media-cleaner.ts
+++ b/src/media/media-cleaner.ts
@@ -1,0 +1,87 @@
+/**
+ * 富媒体过期清理 — 避免下载文件持续膨胀
+ *
+ * 下载目录 ~/.dsh-qqbot/media，文件写入后不再变更，故文件 mtime 即「下载时间」。
+ * 清理时按文件 mtime 判断是否超过保留时长。
+ */
+import { existsSync } from 'node:fs';
+import { readdir, rm, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import type { Context } from '@deepseek-ai/cordis';
+import type { Logger } from '../types.js';
+
+/** 富媒体下载根目录（attachment.ts 复用） */
+export const MEDIA_ROOT = resolve(homedir(), '.dsh-qqbot', 'media');
+
+/** 定期清理间隔（毫秒），固定 1 小时 */
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * 清理过期的富媒体文件（按文件 mtime 判断，异步并发执行，不阻塞事件循环）
+ *
+ * @param ttlHours 保留时长（小时），<=0 表示永不过期（跳过清理）
+ * @returns 删除的文件数
+ */
+export async function cleanupExpiredMedia(ttlHours: number, logger?: Logger): Promise<number> {
+  if (ttlHours <= 0) return 0;
+  if (!existsSync(MEDIA_ROOT)) return 0;
+
+  const now = Date.now();
+  const ttlMs = ttlHours * 60 * 60 * 1000;
+
+  const entries = await readdir(MEDIA_ROOT, { withFileTypes: true });
+  const files = entries.filter(entry => entry.isFile()).map(entry => entry.name);
+
+  const results = await Promise.all(files.map(async (name) => {
+    const filePath = join(MEDIA_ROOT, name);
+    try {
+      const info = await stat(filePath);
+      if (now - info.mtimeMs <= ttlMs) return false;
+      await rm(filePath, { force: true });
+      logger?.debug(`im-qqbot: cleaned expired media: ${name}`);
+      return true;
+    } catch (err) {
+      logger?.warn(`im-qqbot: media cleanup failed for ${name}: ${err instanceof Error ? err.message : String(err)}`);
+      return false;
+    }
+  }));
+
+  return results.filter(Boolean).length;
+}
+
+/**
+ * 启动富媒体过期清理：启动时清理一次 + 定期清理（每 1 小时）
+ *
+ * 用 ctx.effect 挂载定时器，插件卸载时自动 clearInterval。
+ * ttlHours <= 0 时不启动（永不过期）。
+ */
+export function startMediaCleanup(ctx: Context, ttlHours: number, logger: Logger): void {
+  if (ttlHours <= 0) return;
+
+  logger.info(`im-qqbot: media cleanup started (ttl=${ttlHours}h, interval=1h, root=${MEDIA_ROOT})`);
+
+  // 启动时立即清理一次（异步，不阻塞启动流程）
+  void cleanupExpiredMedia(ttlHours, logger)
+    .then((cleaned) => {
+      if (cleaned > 0) logger.info(`im-qqbot: cleaned ${cleaned} expired media files`);
+    })
+    .catch((err) => {
+      logger.warn(`im-qqbot: media cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+
+  (ctx as unknown as { effect(fn: () => (() => Promise<void>) | void, name?: string): void })
+    .effect(() => {
+      const timer = setInterval(() => {
+        void cleanupExpiredMedia(ttlHours, logger)
+          .then((n) => {
+            if (n > 0) logger.info(`im-qqbot: cleaned ${n} expired media files`);
+          })
+          .catch((err) => {
+            logger.warn(`im-qqbot: media cleanup failed: ${err instanceof Error ? err.message : String(err)}`);
+          });
+      }, CLEANUP_INTERVAL_MS);
+
+      return async () => { clearInterval(timer); };
+    }, 'im-qqbot.media-cleanup');
+}

--- a/src/media/vision-tool.ts
+++ b/src/media/vision-tool.ts
@@ -1,0 +1,294 @@
+/**
+ * 内置 qqbot_describe_image 视觉工具。
+ *
+ * 复用 dsh 生态的 llm + attachments 服务（路线 A）：
+ *   1. 加载图片（本地绝对路径 / http URL）→ magic bytes 嗅探 mediaType
+ *   2. attachments.saveImage → ImageAttachmentRef（字节不进 session log）
+ *   3. createUserMessage(ImageBlock + text) → llm.stream → BlockAssembler 收集文本
+ *
+ * 对齐 dsh 官方辅助 LLM 调用范式（session-title-llm）与图片入模范式（apiproxy）。
+ * 手写 ToolDefinition（标准 JSON Schema），避免引入 dsh-tools 的 8 个 peer 依赖。
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import yaml from 'js-yaml';
+import type { Context } from '@deepseek-ai/cordis';
+import { BlockAssembler, createUserMessage } from '@deepseek-ai/dsh-llm';
+import type {
+  ContentBlock,
+  FinishReason,
+  GenerateOptions,
+  ImageBlock,
+  StreamChunk,
+} from '@deepseek-ai/dsh-llm';
+import type { VisionConfig } from '../config.js';
+import type { Logger } from '../types.js';
+
+/** 通过 dsh-llm 的 ImageBlock 间接引用 dsh-attachment 类型，避免直接依赖 dsh-attachment */
+type ImageAttachmentRef = ImageBlock['attachment'];
+type ImageMediaType = ImageAttachmentRef['mediaType'];
+
+/** attachments 服务最小接口 */
+interface AttachmentStoreLike {
+  saveImage(input: { data: Uint8Array; mediaType: ImageMediaType; name?: string }): Promise<ImageAttachmentRef>;
+}
+
+/** llm 服务最小接口 */
+interface LlmRuntimeLike {
+  stream(options: GenerateOptions): AsyncIterable<StreamChunk>;
+}
+
+/** tools 服务最小接口 */
+interface ToolsRegistryLike {
+  register(definition: unknown): unknown;
+}
+
+/** qqbot_describe_image 的合法参数 */
+interface DescribeImageArgs {
+  image: string;
+  prompt?: string;
+}
+
+/** 工具名（qqbot 前缀避免与外部 describe-image 包的同名工具冲突） */
+export const DESCRIBE_IMAGE_TOOL_NAME = 'qqbot_describe_image';
+
+const DESCRIPTION =
+  'Inspect one image and return the text the user needs. The image is a local absolute path '
+  + '(downloaded by the QQ bot) or an http(s) URL. Use this when the user references an image, '
+  + 'or when a task needs OCR, chart/diagram reading, screenshot or UI analysis, translation of '
+  + 'image text, or photo understanding. Always pass an explicit `prompt` with a precise '
+  + 'instruction (e.g. "transcribe all text", "extract the table as CSV", "translate the text '
+  + 'into Chinese") instead of relying on the generic default.';
+
+/** 图片 magic bytes 嗅探 → 标准 MIME（不信声明，安全底线） */
+function sniffImageMediaType(bytes: Uint8Array): ImageMediaType | null {
+  if (bytes.length < 12) return null;
+  // PNG: 89 50 4E 47
+  if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return 'image/png';
+  // JPEG: FF D8 FF
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return 'image/jpeg';
+  // GIF: 47 49 46 38
+  if (bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x38) return 'image/gif';
+  // WEBP: 52 49 46 46 .. 57 45 42 50
+  if (bytes[0] === 0x52 && bytes[1] === 0x49 && bytes[2] === 0x46 && bytes[3] === 0x46
+    && bytes[8] === 0x57 && bytes[9] === 0x45 && bytes[10] === 0x42 && bytes[11] === 0x50) return 'image/webp';
+  return null;
+}
+
+/** 加载图片字节（本地路径 / http URL），校验大小 + 嗅探 MIME */
+async function loadImageBytes(
+  image: string,
+  maxBytes: number,
+  signal: AbortSignal,
+): Promise<{ data: Uint8Array; mediaType: ImageMediaType }> {
+  let data: Uint8Array;
+  if (/^https?:\/\//i.test(image)) {
+    const resp = await fetch(image, { signal, redirect: 'error' });
+    if (!resp.ok) throw new Error(`qqbot_describe_image: download failed (HTTP ${resp.status})`);
+    const buf = Buffer.from(await resp.arrayBuffer());
+    if (buf.length > maxBytes) throw new Error(`qqbot_describe_image: image too large (${buf.length} bytes)`);
+    data = new Uint8Array(buf);
+  } else {
+    const info = await stat(image).catch(() => null);
+    if (!info?.isFile()) throw new Error(`qqbot_describe_image: image file not found: ${image}`);
+    if (info.size > maxBytes) throw new Error(`qqbot_describe_image: image too large (${info.size} bytes)`);
+    data = new Uint8Array(await readFile(image));
+  }
+
+  const mediaType = sniffImageMediaType(data);
+  if (mediaType === null) throw new Error('qqbot_describe_image: unrecognized image format (png/jpeg/gif/webp only)');
+  return { data, mediaType };
+}
+
+/** 将终端 finish reason 转成辅助调用失败 */
+function finishError(finish: FinishReason): Error | undefined {
+  switch (finish.kind) {
+    case 'error':
+    case 'aborted':
+      return new Error(finish.failure.message);
+    default:
+      return undefined;
+  }
+}
+
+/** 调视觉模型描述图片，返回纯文本 */
+async function callVision(
+  llm: LlmRuntimeLike,
+  vision: VisionConfig,
+  prompt: string,
+  imageRef: ImageAttachmentRef,
+  signal: AbortSignal,
+): Promise<string> {
+  const message = createUserMessage({
+    content: [
+      { type: 'image', attachment: imageRef },
+      { type: 'text', text: prompt },
+    ],
+    source: { kind: 'plugin', plugin: 'dsh-im-qqbot' },
+  });
+
+  const options: GenerateOptions = {
+    provider: vision.provider,
+    model: vision.model,
+    messages: [message],
+    maxTokens: vision.maxTokens,
+    signal,
+  };
+
+  const assembler = new BlockAssembler();
+  for await (const chunk of llm.stream(options)) {
+    assembler.push(chunk);
+  }
+  const terminalError = finishError(assembler.finish);
+  if (terminalError !== undefined) throw terminalError;
+
+  const text = assembler.blocks()
+    .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+    .map((block) => block.text)
+    .join(' ')
+    .trim();
+  if (text.length === 0) throw new Error('qqbot_describe_image: vision model returned no text');
+  return text;
+}
+
+/** 展开 `~`/`~/`/`~\` 前缀（对齐 @deepseek-ai/dsh-home-paths 的 expandHomePath） */
+function expandHomePath(path: string): string {
+  if (path === '~') return homedir();
+  if (path.startsWith('~/') || path.startsWith('~\\')) return join(homedir(), path.slice(2));
+  return path;
+}
+
+/**
+ * 解析 DSH_HOME（对齐 dsh 官方 resolveDshHome 的优先级与跨平台处理）：
+ * 显式配置 > `$DSH_HOME`（空/空白视为未设置）> `~/.dsh`，展开 `~` 后 resolve 为绝对路径。
+ */
+function resolveDshHome(): string {
+  const fromEnv = process.env.DSH_HOME;
+  const selected = fromEnv !== undefined && fromEnv.trim().length > 0
+    ? fromEnv
+    : join(homedir(), '.dsh');
+  return resolve(expandHomePath(selected));
+}
+
+/**
+ * 启动时检查 settings.yaml 里 vision 模型的 input 模态是否声明了 image。
+ *
+ * webui 的模型配置界面不暴露 `input` 字段，用户通过 webui 配置的视觉模型默认是纯文本，
+ * 会导致 pi-ai adapter 拒绝图片输入。这里在启动时兜底：未声明 image 时自动补 `[text, image]`。
+ * 幂等（已声明则跳过），解析/写入失败仅 warn 不阻断启动。
+ */
+export function ensureVisionInputModal(vision: VisionConfig, logger: Logger): void {
+  if (!vision.enabled || !vision.provider || !vision.model) return;
+
+  const settingsPath = resolve(resolveDshHome(), 'settings.yaml');
+
+  try {
+    if (!existsSync(settingsPath)) return;
+
+    // YAML 禁止 tab 缩进（webui/编辑器可能写入），读入时把行首 tab 规范化为空格
+    const raw = readFileSync(settingsPath, 'utf8');
+    const normalized = raw.replace(/^\t+/gm, (tabs) => '  '.repeat(tabs.length));
+    const doc = yaml.load(normalized) as Record<string, unknown> | null;
+    if (doc === null || typeof doc !== 'object') return;
+
+    const piAi = doc['llm-pi-ai'] as { providers?: Record<string, unknown> } | undefined;
+    const provider = piAi?.providers?.[vision.provider] as { models?: unknown } | undefined;
+    const models = provider?.models;
+    if (!Array.isArray(models)) {
+      logger.warn(`im-qqbot: settings.yaml 未找到 llm-pi-ai.providers.${vision.provider}.models，请手动确认 vision 模型已声明 image 输入`);
+      return;
+    }
+
+    const model = models.find(
+      (m): m is Record<string, unknown> =>
+        typeof m === 'object' && m !== null && (m as Record<string, unknown>).id === vision.model,
+    );
+    if (model === undefined) {
+      logger.warn(`im-qqbot: settings.yaml 未找到 vision 模型 ${vision.model}，请手动确认已声明 image 输入`);
+      return;
+    }
+
+    const input = model.input;
+    if (Array.isArray(input) && input.includes('image')) return; // 已声明，幂等跳过
+
+    model.input = ['text', 'image'];
+    writeFileSync(settingsPath, yaml.dump(doc), 'utf8');
+    logger.info(`im-qqbot: 已为 vision 模型补充 input: [text, image] (${vision.provider}/${vision.model})`);
+  } catch (err) {
+    logger.warn(`im-qqbot: 检查 settings.yaml vision input 失败: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** 注册 qqbot_describe_image 工具（服务缺失时优雅降级，不阻断插件启动） */
+export function registerDescribeImageTool(ctx: Context, vision: VisionConfig, logger: Logger): void {
+  if (!vision.enabled) return;
+  if (!vision.provider || !vision.model) {
+    logger.warn('im-qqbot: vision.provider/model 未配置，qqbot_describe_image 工具未注册');
+    return;
+  }
+
+  const tools = ctx.get('tools') as ToolsRegistryLike | undefined;
+  const llm = ctx.get('llm') as LlmRuntimeLike | undefined;
+  const attachments = ctx.get('attachments') as AttachmentStoreLike | undefined;
+  if (!tools?.register || !llm?.stream || !attachments?.saveImage) {
+    logger.warn('im-qqbot: tools/llm/attachments 服务不可用，qqbot_describe_image 工具未注册');
+    return;
+  }
+
+  const definition = {
+    name: DESCRIBE_IMAGE_TOOL_NAME,
+    description: DESCRIPTION,
+    parameters: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          description: 'Absolute path to a local image file, or an http(s) URL of the image.',
+        },
+        prompt: {
+          type: 'string',
+          description: 'Your precise instruction for the vision model about this image.',
+        },
+      },
+      required: ['image'],
+      additionalProperties: false,
+    },
+    output: {
+      schema: {
+        type: 'object',
+        properties: {
+          text: { type: 'string' },
+          model: { type: 'string' },
+          image: { type: 'string' },
+          mimeType: { type: 'string', enum: ['image/png', 'image/jpeg', 'image/gif', 'image/webp'] },
+          bytes: { type: 'integer' },
+        },
+        required: ['text', 'model', 'image', 'mimeType', 'bytes'],
+        additionalProperties: false,
+      },
+      render: (_args: unknown, value: unknown): ContentBlock[] => [
+        { type: 'text', text: (value as { text: string }).text },
+      ],
+    },
+    async execute(args: unknown, exec: { signal: AbortSignal }): Promise<Record<string, unknown>> {
+      const { image, prompt } = args as DescribeImageArgs;
+      if (typeof image !== 'string' || image.length === 0) {
+        throw new Error('qqbot_describe_image: `image` must be a non-empty string');
+      }
+
+      const loaded = await loadImageBytes(image, vision.maxBytes, exec.signal);
+      const ref = await attachments.saveImage({
+        data: loaded.data,
+        mediaType: loaded.mediaType,
+        name: /^https?:\/\//i.test(image) ? undefined : basename(image),
+      });
+      const text = await callVision(llm, vision, prompt ?? vision.defaultPrompt, ref, exec.signal);
+      return { text, model: vision.model, image, mimeType: loaded.mediaType, bytes: loaded.data.length };
+    },
+  };
+
+  tools.register(definition);
+  logger.info(`im-qqbot: qqbot_describe_image 工具已注册 (provider=${vision.provider} model=${vision.model})`);
+}

--- a/src/middleware/attachment.ts
+++ b/src/middleware/attachment.ts
@@ -1,23 +1,37 @@
 /**
- * 附件下载中间件 — 在中间件链中下载 file 附件
+ * 富媒体下载中间件 — 在中间件链中下载 image/video/file 附件
  *
  * 结果写入 ctx.state.downloadedFiles，供 handleInbound 读取。
  * 下载失败不阻断消息（记录告警后放行），确保附件异常不影响正常文本处理。
  */
 import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
-import { downloadFileAttachments } from '../transport/attachment.js';
+import { downloadMediaAttachments } from '../transport/attachment.js';
 import type { ImQQBotConfig } from '../config.js';
-import type { Logger, RawAttachment } from '../types.js';
+import type { Logger, QuotedAttachment, RawAttachment } from '../types.js';
 
 export function attachmentProcessor(config: ImQQBotConfig, logger: Logger) {
   return async (ctx: MiddlewareContext, next: () => Promise<void>): Promise<void> => {
-    const msg = ctx.message as { attachments?: RawAttachment[]; messageId?: string };
-    const cwd = config.cwd || process.cwd();
-    const messageId = msg.messageId ?? 'unknown';
+    const msg = ctx.message as { attachments?: RawAttachment[] };
 
     try {
-      const downloaded = await downloadFileAttachments(msg.attachments, cwd, messageId, logger);
+      // 当前消息附件
+      const downloaded = await downloadMediaAttachments(msg.attachments, config.media, logger);
       ctx.state.downloadedFiles = downloaded;
+
+      // 引用消息附件：转成 RawAttachment 结构复用下载（voice 由 downloadMediaAttachments 自动跳过）
+      const quoteAttachments = (ctx.state as { quote?: { attachments?: QuotedAttachment[] } }).quote?.attachments;
+      if (quoteAttachments && quoteAttachments.length > 0) {
+        const rawQuote = quoteAttachments
+          .filter(a => a.url)
+          .map((a): RawAttachment => ({
+            content_type: a.contentType ?? '',
+            filename: a.filename ?? '',
+            size: 0,
+            url: a.url as string,
+          }));
+        const downloadedQuote = await downloadMediaAttachments(rawQuote, config.media, logger);
+        ctx.state.downloadedQuoteFiles = downloadedQuote;
+      }
     } catch (err) {
       logger.warn(`im-qqbot: attachment download failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/transport/attachment.ts
+++ b/src/transport/attachment.ts
@@ -1,34 +1,89 @@
 /**
- * 附件下载 — 将 QQ 文件附件安全下载到本地
+ * 富媒体下载 — 将 QQ 图片/视频/file 附件安全下载到本地
  *
- * 下载后仅通过 @路径 提示模型，由模型通过 tool-bash / tool-fs 自行读取，
- * 不内联内容（避免 token 浪费与上下文污染）。
+ * 下载后仅通过本地绝对路径提示模型，由模型通过 qqbot_describe_image / ffmpeg / tool-fs 等工具自行分析，
+ *
+ * 下载目录固定为 ~/.dsh-qqbot/media（对齐 dsh-qqbot 的 prefs 目录约定），
+ * 文件名用时间戳+随机数防重名，不依赖 agent cwd，便于 qqbot_describe_image / tool-fs 等工具稳定访问。
  */
 import { mkdirSync, writeFileSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, extname, join, sep } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import * as dns from 'node:dns';
 import type { Logger, RawAttachment } from '../types.js';
+import type { MediaConfig } from '../config.js';
+import { MEDIA_ROOT } from '../media/media-cleaner.js';
 
-/** 下载大小上限（超过则跳过下载，仅保留路径提示） */
-const MAX_DOWNLOAD_BYTES = 20 * 1024 * 1024;
+/** 默认富媒体下载大小上限（MB），可被 media.maxMB 覆盖 */
+const DEFAULT_MAX_MB = 200;
 /** 下载超时（毫秒） */
-const DOWNLOAD_TIMEOUT_MS = 15_000;
+const DOWNLOAD_TIMEOUT_MS = 120_000;
 
 /** 下载结果 */
 export interface DownloadedFile {
   /** 原始文件名（用于与消息附件关联） */
   filename: string;
+  /** 附件类型 */
+  contentType: 'image' | 'video' | 'file';
   /** 本地绝对路径 */
   localPath: string;
-  /** 相对 cwd 的显示路径（@提及 / 工具访问用） */
-  displayPath: string;
 }
 
-/** 文件名净化：去路径、过滤危险字符，防止路径穿越 */
+/** 附件归类（QQ 网关的 content_type 是 MIME 类型，如 image/png、video/mp4、audio/silk） */
+export type MediaKind = 'image' | 'video' | 'voice' | 'file';
+
+/** 是否为图片（兼容裸值 'image' 与 MIME 'image/png'） */
+export function isImageContentType(contentType?: string): boolean {
+  return contentType === 'image' || contentType?.startsWith('image/') === true;
+}
+
+/** 是否为视频（兼容裸值 'video' 与 MIME 'video/mp4'） */
+export function isVideoContentType(contentType?: string): boolean {
+  return contentType === 'video' || contentType?.startsWith('video/') === true;
+}
+
+/** 是否为语音（兼容裸值 'voice' 与 MIME 'audio/silk'） */
+export function isVoiceContentType(contentType?: string): boolean {
+  return contentType === 'voice' || contentType?.startsWith('audio/') === true;
+}
+
+/** 归类附件 content_type 为统一类型 */
+export function classifyContentType(contentType?: string): MediaKind {
+  if (isImageContentType(contentType)) return 'image';
+  if (isVideoContentType(contentType)) return 'video';
+  if (isVoiceContentType(contentType)) return 'voice';
+  return 'file';
+}
+
+/** 处理 `//` 开头的协议相对 URL（补 https:） */
+function normalizeUrl(url: string): string {
+  return url.startsWith('//') ? `https:${url}` : url;
+}
+
+/** 文件名净化：去路径、移除非法字符（保留中文等 Unicode 字符），防止路径穿越 */
 function sanitizeFilename(name: string): string {
   const base = basename(name.replace(/\\/g, '/'));
-  const safe = base.replace(/[^a-zA-Z0-9._-]/g, '_');
+  // 仅替换文件系统非法字符（Windows 保留字符 + 控制字符），保留中文/空格等
+  // normalize NFC：统一 Unicode 规范化，避免 macOS(NFD) 与 Linux/Windows(NFC) 存储差异导致路径对不上
+  const safe = base
+    .replace(/[<>:"|?*\x00-\x1f]/g, '_')
+    .trim()
+    .normalize('NFC');
   return safe || 'attachment';
+}
+
+/** 统一路径分隔符为 `/`（POSIX），Node fs 在 Windows 也接受正斜杠，保证注入路径跨平台一致 */
+function toPosixPath(p: string): string {
+  return p.split(sep).join('/');
+}
+
+/** 防重名：文件名 + 时间戳 + 随机数 */
+function uniqueFilename(name: string): string {
+  const base = sanitizeFilename(name);
+  const ext = extname(base);
+  const stem = basename(base, ext);
+  const rand = randomBytes(4).toString('hex');
+  return `${stem}_${Date.now()}_${rand}${ext}`;
 }
 
 /** 字节数格式化 */
@@ -71,7 +126,7 @@ async function assertSafeHostname(hostname: string): Promise<void> {
 
 /** 安全下载：仅 HTTPS + SSRF 防护 + 大小上限 + 超时，返回下载字节数 */
 async function download(url: string, destPath: string, maxBytes: number): Promise<number> {
-  const parsed = new URL(url);
+  const parsed = new URL(normalizeUrl(url));
   if (parsed.protocol !== 'https:') {
     throw new Error(`Only HTTPS allowed: ${parsed.protocol}`);
   }
@@ -89,45 +144,47 @@ async function download(url: string, destPath: string, maxBytes: number): Promis
 }
 
 /**
- * 下载消息中的 file 附件到本地
+ * 下载消息中的富媒体附件（image/video/file）到本地
  *
- * 下载目录为 {cwd}/.qqbot/{messageId}，用 messageId 隔离跨消息重名。
- * 下载失败不返回（由调用方回退描述），下载成功仅保留路径供模型用工具读取。
+ * 下载目录固定为 ~/.dsh-qqbot/media，文件名用时间戳+随机数防重名。
+ * 下载失败不阻断（由调用方回退描述）。
  */
-export async function downloadFileAttachments(
+export async function downloadMediaAttachments(
   attachments: RawAttachment[] | undefined,
-  cwd: string,
-  messageId: string,
+  media: MediaConfig,
   logger: Logger,
 ): Promise<DownloadedFile[]> {
-  const files = (attachments ?? []).filter(a => a.content_type === 'file' && a.url);
-  if (files.length === 0) return [];
+  if (!media.enabled) return [];
 
-  const dir = join(cwd, '.qqbot', messageId);
-  mkdirSync(dir, { recursive: true });
+  const targets = (attachments ?? []).filter(a =>
+    classifyContentType(a.content_type) !== 'voice' && a.url,
+  );
+  if (targets.length === 0) return [];
+
+  mkdirSync(MEDIA_ROOT, { recursive: true });
+
+  const maxBytes = (media.maxMB ?? DEFAULT_MAX_MB) * 1024 * 1024;
 
   const results: DownloadedFile[] = [];
-  for (const file of files) {
-    const safeName = sanitizeFilename(file.filename);
-    const localPath = join(dir, safeName);
-    const displayPath = `.qqbot/${messageId}/${safeName}`;
+  for (const att of targets) {
+    const contentType = classifyContentType(att.content_type) as 'image' | 'video' | 'file';
+    const localPath = toPosixPath(join(MEDIA_ROOT, uniqueFilename(att.filename)));
 
-    if (file.size > MAX_DOWNLOAD_BYTES) {
-      logger.debug(`im-qqbot: skip download (${file.size}B too large): ${file.filename}`);
-      results.push({ filename: file.filename, localPath, displayPath });
-      continue;
+    if (att.size > maxBytes) {
+      logger.debug(`im-qqbot: skip download (${att.size}B too large): ${att.filename}`);
+      continue; // 超限不下载，由 buildDynamicCtx 回退为描述
     }
 
     let bytes: number;
     try {
-      bytes = await download(file.url, localPath, MAX_DOWNLOAD_BYTES);
+      bytes = await download(att.url, localPath, maxBytes);
     } catch (err) {
-      logger.warn(`im-qqbot: download failed: ${file.filename} — ${err instanceof Error ? err.message : String(err)}`);
+      logger.warn(`im-qqbot: download failed: ${att.filename} — ${err instanceof Error ? err.message : String(err)}`);
       continue; // 下载失败不加入结果，由 buildDynamicCtx 回退为描述
     }
-    logger.debug(`im-qqbot: attachment downloaded: ${file.filename} (${formatSize(bytes)}) → ${displayPath}`);
+    logger.debug(`im-qqbot: attachment downloaded: ${att.filename} (${formatSize(bytes)}) → ${localPath}`);
 
-    results.push({ filename: file.filename, localPath, displayPath });
+    results.push({ filename: att.filename, contentType, localPath });
   }
 
   return results;

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -2,7 +2,7 @@
  * 入站处理器 — 经 SDK 中间件链处理后的消息 → dsh Agent followup
  *
  * 对齐 openclaw-qqbot body-assembler 的内容组装逻辑：
- * - Layer 1: userContent（文本 + 语音转录 + 附件描述）
+ * - Layer 1: userContent（文本 + 语音转录）
  * - Layer 2: quotePart（引用消息块）
  * - Layer 3: userMessage（带发送者标签）
  * - Layer 4: dynamicCtx（媒体元数据）
@@ -12,8 +12,13 @@ import type { ContentBlock } from '@deepseek-ai/dsh-llm';
 import { createUserMessage } from '@deepseek-ai/dsh-llm';
 import type { SessionManager } from '../session/index.js';
 import type { ImQQBotConfig } from '../config.js';
-import type { ChatScope, Logger, RawAttachment, ReplyTarget } from '../types.js';
-import type { DownloadedFile } from './attachment.js';
+import type { ChatScope, Logger, QuotedAttachment, RawAttachment, ReplyTarget } from '../types.js';
+import {
+  classifyContentType,
+  isVoiceContentType,
+  type DownloadedFile,
+  type MediaKind,
+} from './attachment.js';
 import { clearGroupHistory } from '../features/history-store.js';
 
 // ── 类型定义 ──
@@ -35,7 +40,7 @@ interface ProcessedMessage {
 interface ResolvedQuote {
   text?: string;
   entry?: { senderId?: string; content?: string };
-  attachments?: { contentType?: string; url?: string; filename?: string; asrText?: string }[];
+  attachments?: QuotedAttachment[];
 }
 
 interface HistoryEntry {
@@ -57,6 +62,7 @@ interface MiddlewareState {
   mention?: MentionState;
   processedAttachments?: ProcessedAttachment[];
   downloadedFiles?: DownloadedFile[];
+  downloadedQuoteFiles?: DownloadedFile[];
   [key: string]: unknown;
 }
 
@@ -97,11 +103,8 @@ export async function handleInbound(
     msgId: msg.messageId,
   };
 
-  // ── 读取中间件已下载的文件（attachmentProcessor 写入 state.downloadedFiles） ──
-  const downloaded = mwState.downloadedFiles ?? [];
-
-  // ── 组装 agentBody（对齐 openclaw-qqbot body-assembler） ──
-  const agentBody = assembleAgentBody(msg, mwState, scope, logger, downloaded);
+  // ── 组装 agentBody（下载结果经 mwState.downloadedFiles 提供） ──
+  const agentBody = assembleAgentBody(msg, mwState, scope, logger);
 
   if (!agentBody) return;
 
@@ -145,19 +148,18 @@ function assembleAgentBody(
   state: MiddlewareState,
   scope: ChatScope,
   logger: Logger,
-  downloaded: DownloadedFile[],
 ): string | null {
-  const userContent = buildUserContent(msg, state, logger);
-
-  if (!userContent && (!msg.attachments || msg.attachments.length === 0)) return null;
-
-  const quotePart = buildQuotePart(state.quote);
-
   const isGroup = scope === 'group';
   const wasMentioned = state.mention?.wasMentioned ?? false;
+
+  const userContent = buildUserContent(msg, state, logger);
+
+  if (isEmptyMessage(userContent, msg.attachments, isGroup, wasMentioned)) return null;
+
+  const quotePart = buildQuotePart(state.quote);
   const userMessage = buildUserMessage(userContent, quotePart, msg.senderId, msg.senderName, isGroup, wasMentioned);
 
-  const dynamicCtx = buildDynamicCtx(msg, state, downloaded);
+  const dynamicCtx = buildDynamicCtx(msg, state);
 
   const base = dynamicCtx ? `${dynamicCtx}${userMessage}` : userMessage;
   const agentBody = buildAgentBody(base, state.history, isGroup, wasMentioned);
@@ -166,7 +168,23 @@ function assembleAgentBody(
 }
 
 /**
- * Layer 1: 用户文本内容 + 语音 + 附件
+ * 判断消息是否为空：无文本/语音/附件，且非群聊 @。
+ * 群聊被 @ 视为有效触发信号，即使内容为空也保留给 agent。
+ */
+function isEmptyMessage(
+  userContent: string,
+  attachments: RawAttachment[] | undefined,
+  isGroup: boolean,
+  wasMentioned: boolean,
+): boolean {
+  if (userContent) return false;
+  if (attachments && attachments.length > 0) return false;
+  if (isGroup && wasMentioned) return false;
+  return true;
+}
+
+/**
+ * Layer 1: 用户文本内容 + 语音转录 + 附件类型标签（媒体路径由 buildDynamicCtx 提供）
  */
 function buildUserContent(msg: ProcessedMessage, state: MiddlewareState, logger: Logger): string {
   const parts: string[] = [];
@@ -184,9 +202,10 @@ function buildUserContent(msg: ProcessedMessage, state: MiddlewareState, logger:
     }
   }
 
-  const otherAttachments = describeAttachments(msg.attachments, state.processedAttachments);
-  if (otherAttachments) {
-    parts.push(otherAttachments);
+  // 附件类型标签（媒体路径由 buildDynamicCtx 提供，这里只提示「带了什么」）
+  const attachmentTags = buildAttachmentTags(msg.attachments);
+  if (attachmentTags) {
+    parts.push(attachmentTags);
   }
 
   return parts.join('\n');
@@ -225,64 +244,82 @@ function buildUserMessage(
 }
 
 /**
- * Layer 4: 媒体元数据上下文
+ * Layer 4: 媒体元数据上下文（图片/视频/文件本地路径 + 语音 ASR + 引用附件）
  */
-function buildDynamicCtx(msg: ProcessedMessage, state: MiddlewareState, downloaded: DownloadedFile[]): string {
+function buildDynamicCtx(msg: ProcessedMessage, state: MiddlewareState): string {
   const lines: string[] = [];
 
-  if (!msg.attachments || msg.attachments.length === 0) return '';
+  if (msg.attachments && msg.attachments.length > 0) {
+    const downloadedByFilename = new Map((state.downloadedFiles ?? []).map(d => [d.filename, d]));
+    const voices: RawAttachment[] = [];
 
-  const images = msg.attachments.filter(a => a.content_type === 'image');
-  if (images.length > 0) {
-    const urls = images.map(a => a.url).filter(Boolean);
-    if (urls.length > 0) {
-      lines.push(`- Images: ${urls.join(', ')}`);
-    }
-  }
-
-  const voices = msg.attachments.filter(a => a.content_type === 'voice');
-  if (voices.length > 0) {
-    const asrTexts = voices.map(a => a.asr_refer_text).filter(Boolean);
-    if (asrTexts.length > 0) {
-      lines.push(`- ASR: ${asrTexts.join(' | ')}`);
-    } else {
-      // 无 ASR 识别结果时才带链接（纯文本模型无法消费音频，链接无意义）
-      const urls = voices.map(a => a.url).filter(Boolean);
-      if (urls.length > 0) {
-        lines.push(`- Voice: ${urls.join(', ')}`);
+    // 一次遍历归类 + 生成媒体行
+    for (const att of msg.attachments) {
+      const kind = classifyContentType(att.content_type);
+      if (kind === 'voice') {
+        voices.push(att);
+        continue;
       }
+      const d = downloadedByFilename.get(att.filename);
+      lines.push(`- ${renderMediaLine(kind, att.filename, d?.localPath, att.url, att.size)}`);
     }
-  }
 
-  const videos = msg.attachments.filter(a => a.content_type === 'video');
-  if (videos.length > 0) {
-    lines.push(`- Videos: ${videos.map(a => a.filename).join(', ')}`);
-  }
-
-  const files = msg.attachments.filter(a => a.content_type === 'file');
-  if (files.length > 0) {
-    for (const file of files) {
-      const d = downloaded.find(x => x.filename === file.filename);
-      if (d) {
-        lines.push(`- File: ${file.filename} → ${d.displayPath}`);
+    // 语音：有 ASR 文本才带文本，否则只带链接（纯文本模型无法消费音频）
+    if (voices.length > 0) {
+      const asrTexts = voices.map(a => a.asr_refer_text).filter(Boolean);
+      if (asrTexts.length > 0) {
+        lines.push(`- ASR: ${asrTexts.join(' | ')}`);
       } else {
-        lines.push(`- File: ${file.filename} (${formatFileSize(file.size)})`);
+        const urls = voices.map(a => a.url).filter(Boolean);
+        if (urls.length > 0) lines.push(`- Voice: ${urls.join(', ')}`);
       }
     }
   }
 
-  if (lines.length === 0) return '';
-
+  // 引用消息的附件（独立于当前消息媒体，不受上一步为空影响）
   const quoteAttachments = state.quote?.attachments;
   if (quoteAttachments && quoteAttachments.length > 0) {
+    const downloadedQuote = new Map((state.downloadedQuoteFiles ?? []).map(d => [d.filename, d]));
     lines.push('[Reference attachments]');
     for (const qa of quoteAttachments) {
-      const label = qa.asrText ? `Voice: ${qa.asrText}` : (qa.filename ?? qa.contentType ?? 'attachment');
-      lines.push(`  - ${label}`);
+      const kind = classifyContentType(qa.contentType);
+      const d = downloadedQuote.get(qa.filename ?? '');
+      if (kind === 'voice') {
+        if (qa.asrText) lines.push(`  - Voice: ${qa.asrText}`);
+        continue;
+      }
+      lines.push(`  - ${renderMediaLine(kind, qa.filename, d?.localPath, qa.url, undefined)}`);
     }
   }
 
-  return lines.join('\n') + '\n\n';
+  return lines.length > 0 ? lines.join('\n') + '\n\n' : '';
+}
+
+/**
+ * 渲染单个媒体附件（image/video/file）的上下文行内容，不含列表前缀。
+ * 当前消息与引用消息共用，保证附件格式统一。语音不在此处理（见 buildDynamicCtx）。
+ */
+function renderMediaLine(
+  kind: Exclude<MediaKind, 'voice'>,
+  filename: string | undefined,
+  localPath: string | undefined,
+  url: string | undefined,
+  size: number | undefined,
+): string {
+  switch (kind) {
+    case 'image':
+      return localPath
+        ? `Image: ${localPath}`
+        : `Image: ${url ?? filename ?? 'image'}`;
+    case 'video':
+      return localPath
+        ? `Video: ${localPath}`
+        : `Video: ${filename ?? 'video'} (download failed)`;
+    case 'file':
+      return localPath
+        ? `File: ${localPath}`
+        : `File: ${filename ?? 'file'} (${formatFileSize(size ?? 0)})`;
+  }
 }
 
 /**
@@ -344,7 +381,7 @@ function extractVoiceTexts(
 
   if (results.length === 0 && attachments) {
     for (const att of attachments) {
-      if (att.content_type === 'voice' && att.asr_refer_text) {
+      if (isVoiceContentType(att.content_type) && att.asr_refer_text) {
         results.push({
           text: att.asr_refer_text.trim(),
           source: 'asr',
@@ -356,36 +393,31 @@ function extractVoiceTexts(
   return results;
 }
 
-function describeAttachments(
-  attachments?: RawAttachment[],
-  _processed?: ProcessedAttachment[],
-): string {
+/**
+ * 附件类型标签（Layer 1 用户消息主体里的轻量提示）。
+ * 只标注「带了什么类型的附件」，去重；媒体本地路径在 buildDynamicCtx 提供。
+ */
+function buildAttachmentTags(attachments?: RawAttachment[]): string {
   if (!attachments || attachments.length === 0) return '';
 
-  const parts: string[] = [];
+  const labels: Record<string, string> = {
+    image: '[图片]',
+    video: '[视频]',
+    file: '[文件]',
+  };
+
+  const seen = new Set<string>();
+  const tags: string[] = [];
 
   for (const att of attachments) {
-    switch (att.content_type) {
-      case 'voice':
-        break;
-      case 'image': {
-        const dim = att.width && att.height ? ` ${att.width}×${att.height}` : '';
-        parts.push(`[Image: ${att.filename}${dim}]`);
-        break;
-      }
-      case 'video':
-        parts.push(`[Video: ${att.filename}]`);
-        break;
-      case 'file':
-        parts.push(`[File: ${att.filename} (${formatFileSize(att.size)})]`);
-        break;
-      default:
-        parts.push(`[Attachment: ${att.filename ?? att.content_type}]`);
-        break;
-    }
+    const kind = classifyContentType(att.content_type);
+    if (kind === 'voice' || seen.has(kind)) continue;
+    seen.add(kind);
+    const label = labels[kind];
+    if (label) tags.push(label);
   }
 
-  return parts.join('\n');
+  return tags.join(' ');
 }
 
 function formatFileSize(bytes: number): string {

--- a/src/types-augment.d.ts
+++ b/src/types-augment.d.ts
@@ -5,14 +5,17 @@
  * 项目自定义中间件填充的 well-known keys 类型声明。
  *
  * 这些字段由项目中间件填充：
- * - downloadedFiles: attachmentProcessor 中间件 → 下载到本地的 file 附件
+ * - downloadedFiles: attachmentProcessor 中间件 → 下载到本地的当前消息附件
+ * - downloadedQuoteFiles: attachmentProcessor 中间件 → 下载到本地的引用消息附件
  */
 import '@tencent-connect/qqbot-nodejs';
 import type { DownloadedFile } from './transport/attachment.js';
 
 declare module '@tencent-connect/qqbot-nodejs' {
   interface MiddlewareState {
-    /** attachmentProcessor 下载到本地的 file 附件结果 */
+    /** attachmentProcessor 下载到本地的当前消息附件结果 */
     downloadedFiles?: DownloadedFile[];
+    /** attachmentProcessor 下载到本地的引用消息附件结果 */
+    downloadedQuoteFiles?: DownloadedFile[];
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,23 +12,6 @@ export interface ReplyTarget {
   msgId?: string;
 }
 
-/** QQ 入站消息（简化） */
-export interface QQInboundMessage {
-  content?: string;
-  senderId: string;
-  groupOpenid?: string;
-  replyTarget: ReplyTarget;
-  attachments?: QQAttachment[];
-}
-
-/** QQ 附件 */
-export interface QQAttachment {
-  contentType: string;
-  filename?: string;
-  url?: string;
-  size?: number;
-}
-
 /** SDK 原始消息附件（snake_case 字段，来自 QQ 网关 C2C_MESSAGE_CREATE） */
 export interface RawAttachment {
   content_type: string;
@@ -39,6 +22,14 @@ export interface RawAttachment {
   width?: number;
   height?: number;
   [key: string]: unknown;
+}
+
+/** 引用消息附件（quoteRef 中间件解析的 camelCase 视图） */
+export interface QuotedAttachment {
+  contentType?: string;
+  url?: string;
+  filename?: string;
+  asrText?: string;
 }
 
 /** 插件 Logger 接口 */


### PR DESCRIPTION
## Summary

Add rich-media understanding to the QQ Bot: download `image` / `video` / `file` attachments into local storage, expose a `qqbot_describe_image` vision tool for the agent, and periodically clean up expired media via TTL.

## Changes

### 1. Rich-media download pipeline

- `attachmentProcessor` middleware now downloads `image`, `video`, and `file` attachments (previously `file` only) into `~/.dsh-qqbot/media`, without blocking the message on download failure.
- Attachment metadata is classified by content type (`image` / `video` / `file` / `voice`).
- The inbound renderer now attaches a lightweight type tag (`[图片]` / `[视频]` / `[文件]`) to the user message, while the local media paths are injected through `buildDynamicCtx`.
- Added support for downloading attachments from **quoted messages** (`downloadedQuoteFiles`).

### 2. New `qqbot_describe_image` vision tool

`src/media/vision-tool.ts` registers a built-in tool that lets the agent inspect an image:

- Accepts a local absolute path or an http(s) URL.
- Loads bytes and sniffs the real MIME type via magic bytes (`png` / `jpeg` / `gif` / `webp`), never trusting the declared type.
- Saves the image through the dsh `attachments.saveImage` service (bytes stay out of the session log), then streams the vision model via the dsh `llm` service using `BlockAssembler`.
- Reuses the dsh `llm` + `attachments` services (route A) and aligns with the official `session-title-llm` / `apiproxy` paradigms, with a hand-written ToolDefinition to avoid dsh-tools peer dependencies.
- Falls back gracefully (only a warning) when the service is unavailable.

### 3. Media TTL cleanup

`src/media/media-cleaner.ts`:

- Cleans expired media based on file `mtime` (files are write-once after download).
- Runs once at startup and then every hour via a `ctx.effect` timer that is auto-cleared on plugin unload.
- `ttlHours <= 0` disables cleanup (never expires).

### 4. Configuration

- Added `MediaConfig` (`enabled` / `maxMB` / `ttlHours`) and `VisionConfig` (`enabled` / `provider` / `model` / `defaultPrompt` / `maxBytes` / `maxTokens` / `timeoutMs`) with schema defaults.
- Added a startup safeguard that patches the vision model's `input` modal to `[text, image]` in `settings.yaml` when the webui didn't declare it (idempotent; otherwise `pi-ai` rejects image input).
- Updated `cordis.yml` to register `dsh-attachment-local` and `dsh-llm-pi-ai` (Hunyuan Vision) plus the `vision` config block.

## Configuration example

```yaml
media:
  enabled: true
  maxMB: 200
  ttlHours: 24

vision:
  enabled: true
  provider: hunyuan
  model: hunyuan-vision
