### PR TITLE
fix(transport): 串行化每会话 followup，避免打断运行中 turn 导致会话日志损坏

### DIFF
--- a/src/transport/inbound-followup.test.ts
+++ b/src/transport/inbound-followup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleInbound } from './inbound.js';
+import type { SessionManager } from '../session/index.js';
+import type { ImQQBotConfig } from '../config.js';
+import type { Logger } from '../types.js';
+import type { SessionRecord } from '../session/types.js';
+
+function createLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+/** 手动控制的 idle 门槛：resolve 之前 whenIdle() 一直挂着 */
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** 让所有挂起的微任务落定 */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function createRecord(key: string, peerId: string, idle: Promise<void>): SessionRecord {
+  const agent = {
+    id: `agent-${peerId}`,
+    ctx: {},
+    status: 'running',
+    session: { id: `sess-${peerId}` },
+    cancel: vi.fn(),
+    followup: vi.fn(),
+    whenIdle: vi.fn(() => idle),
+    runMaintenance: vi.fn(),
+  };
+  return {
+    sessionKey: key,
+    sessionId: `sess-${peerId}`,
+    agent: agent as unknown as SessionRecord['agent'],
+    handle: { agent, dispose: vi.fn() } as unknown as SessionRecord['handle'],
+    replyTarget: { scope: 'c2c', targetId: peerId, msgId: 'm0' },
+    scope: 'c2c',
+    peerId,
+    senderId: peerId,
+    lastActivity: Date.now(),
+  };
+}
+
+function createManager(record: SessionRecord, current?: () => SessionRecord | undefined) {
+  return {
+    getOrCreate: vi.fn(async () => record),
+    getSessionRecord: vi.fn(() => (current ? current() : record)),
+  } as unknown as SessionManager;
+}
+
+const config = { appId: 'test-app' } as ImQQBotConfig;
+
+function inboundMsg(peerId: string, text: string, msgId: string) {
+  return { kind: 'c2c', senderId: peerId, content: text, messageId: msgId, timestamp: '' };
+}
+
+describe('handleInbound followup 串行化', () => {
+  it('上一轮未 idle 时新消息排队，idle 后按到达顺序投递', async () => {
+    const idle = createDeferred();
+    const record = createRecord('qqbot:test-app:c2c:userA', 'userA', idle.promise);
+    const manager = createManager(record);
+
+    await handleInbound(inboundMsg('userA', 'one', 'm1'), manager, config, createLogger());
+    await handleInbound(inboundMsg('userA', 'two', 'm2'), manager, config, createLogger());
+
+    // 第一个 turn 仍在运行：两条 followup 都不允许投递
+    expect(record.agent.followup).not.toHaveBeenCalled();
+
+    idle.resolve();
+    await flush();
+
+    expect(record.agent.followup).toHaveBeenCalledTimes(2);
+    const texts = record.agent.followup.mock.calls.map(
+      (call) => (call[0] as { content: Array<{ text?: string }> }).content[0]?.text,
+    );
+    expect(texts).toEqual(['one', 'two']);
+  });
+
+  it('等待期间会话被替换（回收/fork）时丢弃排队消息，不投给失效 agent', async () => {
+    const idle = createDeferred();
+    const record = createRecord('qqbot:test-app:c2c:userB', 'userB', idle.promise);
+    const replacement = createRecord('qqbot:test-app:c2c:userB', 'userB', Promise.resolve());
+    let current: SessionRecord | undefined = record;
+    const manager = createManager(record, () => current);
+
+    await handleInbound(inboundMsg('userB', 'queued', 'm1'), manager, config, createLogger());
+    expect(record.agent.followup).not.toHaveBeenCalled();
+
+    // 模拟排队期间会话被 idle 回收或模型切换 fork 替换
+    current = replacement;
+    idle.resolve();
+    await flush();
+
+    expect(record.agent.followup).not.toHaveBeenCalled();
+    expect(replacement.agent.followup).not.toHaveBeenCalled();
+  });
+});

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -79,6 +79,14 @@ interface ProcessedAttachment {
   size?: number;
 }
 
+// ── followup 串行队列 ──
+//
+// 每个会话一条 FIFO 队列：新消息排到队尾，等该会话上一轮完全结束
+// （agent.whenIdle()）后才投递 followup。直接 followup 会打断正在运行
+// 的 turn——被打断的 turn 迟到的流式事件仍会带着预分配序号落盘，
+// 造成会话日志事件乱序/序号回退，最终损坏整个会话记录。
+const followupQueues = new Map<string, Promise<void>>();
+
 // ── 主处理函数 ──
 
 /**
@@ -119,7 +127,7 @@ export async function handleInbound(
     return;
   }
 
-  // ── 构建 UserMessage → followup ──
+  // ── 构建 UserMessage → followup（串行化：等该会话空闲后再发，绝不打断运行中的 turn） ──
   const content: ContentBlock[] = [{ type: 'text' as const, text: agentBody }];
 
   const message = createUserMessage({
@@ -127,8 +135,17 @@ export async function handleInbound(
     source: { kind: 'user' as const },
   });
 
-  record.agent.followup(message);
-  logger.info(`→ followup sent: key=${scope}:${peerId}`);
+  const key = record.sessionKey;
+  const prev = followupQueues.get(key) ?? Promise.resolve();
+  const next = prev.then(async () => {
+    // 会话已被回收/替换则放弃投递，避免发给错误的 agent
+    if (manager.getSessionRecord(scope, peerId) !== record) return;
+    await record.agent.whenIdle().catch(() => {});
+    if (manager.getSessionRecord(scope, peerId) !== record) return;
+    record.agent.followup(message);
+    logger.info(`→ followup sent: key=${scope}:${peerId}`);
+  });
+  followupQueues.set(key, next.catch(() => {}));
 
   // 群消息回复后清空历史缓存（避免下次 @ 时重复组包，对齐 openclaw-qqbot dispatch）
   if (scope === 'group') {


### PR DESCRIPTION
## 背景 / 问题

`concurrencyGuard`（`merge` 策略）的 busy 窗口只覆盖中间件链本身：`handleInbound` 一返回锁就释放。但 `record.agent.followup()` 是 fire-and-forget——agent turn 仍在异步运行。用户连续发消息时，合并批次的 survivor 很快走到 `handleInbound`，它的 followup 可能直接打进仍在运行的上一轮 turn，把该 turn 打断。

这不只是体验问题（用户看到"本轮异常结束"）：**被打断 turn 的迟到流式事件仍会带着预分配的 seq 追加落盘**，造成会话日志序号回退/乱序。dsh 会话日志按严格序号连续性读取，一旦断裂，整个会话历史就无法再加载（我们在真实部署中遇到一次：长 turn 被打断后，整个会话记录彻底无法读取，只能靠离线脚本平移序号修复）。

## 修复

`handleInbound` 内为每个会话维护一条 FIFO 队列（`followupQueues`）：

- 新消息的 followup 排到队尾，等该会话 `agent.whenIdle()` 落定后再投递——绝不打断运行中的 turn；
- 等待期间若会话已被 idle 回收（`sessionIdleTimeout`）或 fork 替换（模型切换），丢弃该排队消息，避免投给失效 agent。

与现有中间件链的交互不变：`merge` 守卫照常合并同批消息，`/bot-stop` 等斜杠命令在守卫之前处理、不受影响。

## 验证

- 新增 `inbound-followup.test.ts`（vitest）：① 上一轮未 idle 时两条消息排队、idle 后按到达顺序投递；② 等待期间会话被替换时丢弃排队消息。
- `pnpm build`（tsc）通过；全部 16 个测试通过（14 个既有 + 2 个新增）。
- 本修复的编译产物已在真实生产部署（0.4.0 + 该补丁）中运行验证。

## 备注

长 turn（含联网搜索等工具调用）还可能被 `concurrencyGuard` 看门狗在 `processingTimeoutMs`（默认 120000ms）处中断并触发同类损坏——建议评估调高该默认值或在 README 中提示配置。日志层面的迟到事件竞态属于 dsh 核心问题，已另行向 deepseek-harness 反馈。
