### PR TITLE
feat(features): QQ 通道支持 ask_user_question 交互式提问（文本+按钮作答）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
+## [Unreleased]
+
+### 新功能
+
+- **交互式提问支持**：agent 使用 `ask_user_question` 工具提问时，QQ 端会收到编号选项文本；单选带选项的问题附带可点击按钮，点击即作答（也支持回复编号或自由文本）。Web 端的弹出框行为不受影响。
+
 ## [0.4.0] - 2026-08-16
 
 ### 新功能

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ src/
 │   ├── scope.ts                # scope/peer 提取
 │   └── send-helper.ts          # 分块发送
 ├── commands/                   # 斜杠命令
+├── features/                   # 功能模块
+│   └── question-channel.ts     # ask_user_question → QQ 文本/按钮问答
 └── typings/                    # 外部模块声明
 ```
 
@@ -125,6 +127,7 @@ sessionKey: `qqbot:${appId}:${scope}:${peerId}`，由 SHA-256 确定性派生 Se
 - **Preset 支持** — 可通过 `agent-presets` 服务挂载预设（工具集、prompt 等）
 - **闲置回收** — 超时自动 dispose Agent，防止内存泄漏
 - **Markdown 输出** — 回复以 Markdown 格式发送，支持代码块/表格感知切分
+- **交互式提问** — `ask_user_question` 在 QQ 端渲染为编号选项文本 + 可点击按钮（单选），回复或点击即作答；其他会话保持原有弹出框行为
 
 ## 本地开发
 

--- a/src/features/question-channel.test.ts
+++ b/src/features/question-channel.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { InteractionEvent } from '@tencent-connect/qqbot-nodejs';
+import {
+  QuestionChannel,
+  buildKeyboard,
+  formatQuestions,
+  parseAnswers,
+  type UserQuestion,
+  type UserQuestionRequest,
+  type UserQuestionResult,
+  type QuestionSessionRecordLike,
+} from './question-channel.js';
+import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+
+function createLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+interface SentMessage {
+  text: string;
+  opts?: { keyboard?: unknown };
+}
+
+function createSender(sent: SentMessage[], opts?: { failKeyboard?: boolean }) {
+  return {
+    sendMarkdown: vi.fn(async (_target: ReplyTarget, content: string, o?: { keyboard?: unknown }) => {
+      if (o?.keyboard && opts?.failKeyboard) throw new Error('keyboard not permitted');
+      sent.push({ text: content, opts: o });
+    }),
+  };
+}
+
+const sessionKey = (scope: ChatScope, peerId: string): string => `qqbot:app:${scope}:${peerId}`;
+
+function createManager(findBySessionId?: (id: string) => QuestionSessionRecordLike | undefined) {
+  return { findBySessionId: findBySessionId ?? (() => undefined), sessionKey };
+}
+
+function makeRecord(sessionKeyStr: string, scope: ChatScope = 'c2c'): QuestionSessionRecordLike {
+  return { sessionKey: sessionKeyStr, scope, replyTarget: { scope, targetId: 'x', msgId: 'm' } };
+}
+
+/** 发起提问，返回答案 Promise（pending 的写入在发送完成后，作答前先等发送落定） */
+function startAsk(
+  ch: QuestionChannel,
+  key: string,
+  questions: UserQuestion[],
+  scope: ChatScope = 'c2c',
+  signal?: AbortSignal,
+): Promise<UserQuestionResult> {
+  const request: UserQuestionRequest = { questions, ...(signal ? { signal } : {}) };
+  return ch.askViaQQ(makeRecord(key, scope), request);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+const q2 = (id = 'q'): UserQuestion => ({ id, question: '选哪个？', options: [{ label: 'A' }, { label: 'B' }] });
+
+describe('formatQuestions', () => {
+  it('renders numbered options and text hint', () => {
+    const text = formatQuestions([q2()], false, false);
+    expect(text).toContain('1. A');
+    expect(text).toContain('2. B');
+    expect(text).toContain('回复编号选择');
+  });
+
+  it('uses button hint when withButtons', () => {
+    expect(formatQuestions([q2()], false, true)).toContain('点击下方按钮选择');
+  });
+
+  it('adds @mention note for groups', () => {
+    expect(formatQuestions([q2()], true, false)).toContain('需 @机器人');
+  });
+
+  it('notes multi-select usage', () => {
+    const q: UserQuestion = { ...q2(), multiSelect: true };
+    expect(formatQuestions([q], false, false)).toContain('可多选');
+  });
+});
+
+describe('buildKeyboard', () => {
+  it('builds one row per option for single-select questions', () => {
+    const kb = buildKeyboard([q2()]);
+    expect(kb?.content.rows).toHaveLength(2);
+    const btn = kb?.content.rows[0]?.buttons[0];
+    expect(btn?.action.type).toBe(1); // 1=回调：点击即确认（2=填输入框，0=跳转）
+    expect(btn?.action.permission.type).toBe(2); // 0 实测会报"无权限操作"
+    expect(btn?.render_data.label).toBe('A');
+    expect(JSON.parse(btn!.action.data)).toEqual({ i: 0 });
+  });
+
+  it('returns undefined for multi-select, no-options, or multi-question', () => {
+    expect(buildKeyboard([{ ...q2(), multiSelect: true }])).toBeUndefined();
+    expect(buildKeyboard([{ id: 'q', question: 't' }])).toBeUndefined();
+    expect(buildKeyboard([q2(), q2('q2')])).toBeUndefined();
+  });
+
+  it('truncates long labels', () => {
+    const long = '这是一个非常非常长的选项标签超过十八个字符的限制了吧';
+    const kb = buildKeyboard([{ id: 'q', question: 't', options: [{ label: long }] }]);
+    const label = kb?.content.rows[0]?.buttons[0]?.render_data.label ?? '';
+    expect(label.length).toBeLessThanOrEqual(18);
+    expect(label.endsWith('…')).toBe(true);
+  });
+});
+
+describe('parseAnswers', () => {
+  it('maps numbers to option labels', () => {
+    expect(parseAnswers([q2()], '2')).toEqual([{ id: 'q', selected: ['B'] }]);
+  });
+
+  it('supports multi-select numbers', () => {
+    const q: UserQuestion = { id: 'q', question: 't', options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }], multiSelect: true };
+    expect(parseAnswers([q], '1,3')).toEqual([{ id: 'q', selected: ['A', 'C'] }]);
+  });
+
+  it('matches exact labels case-insensitively', () => {
+    const q: UserQuestion = { id: 'q', question: 't', options: [{ label: 'Option X' }] };
+    expect(parseAnswers([q], 'option x')).toEqual([{ id: 'q', selected: ['Option X'] }]);
+  });
+
+  it('falls back to custom for out-of-range numbers and free text', () => {
+    expect(parseAnswers([q2()], '9')).toEqual([{ id: 'q', selected: [], custom: '9' }]);
+    expect(parseAnswers([q2()], '自定义')).toEqual([{ id: 'q', selected: [], custom: '自定义' }]);
+  });
+
+  it('no options → custom', () => {
+    expect(parseAnswers([{ id: 'q', question: 't' }], '小明')).toEqual([{ id: 'q', selected: [], custom: '小明' }]);
+  });
+
+  it('multiple questions → custom broadcast', () => {
+    expect(parseAnswers([{ id: 'a', question: '1' }, { id: 'b', question: '2' }], '统一回复'))
+      .toEqual([{ id: 'a', selected: [], custom: '统一回复' }, { id: 'b', selected: [], custom: '统一回复' }]);
+  });
+});
+
+describe('QuestionChannel.tryAnswer', () => {
+  it('resolves pending question and consumes the message', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const p = startAsk(ch, 'k1', [q2()]);
+    await sleep(20);
+    expect(ch.tryAnswer('k1', '2')).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['B'] }] });
+  });
+
+  it('ignores empty text (keeps waiting)', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const p = startAsk(ch, 'k1', [q2()]);
+    await sleep(20);
+    expect(ch.tryAnswer('k1', '')).toBe(false);
+    expect(ch.tryAnswer('k1', '1')).toBe(true);
+    await p;
+  });
+
+  it('returns false when no pending question', () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    expect(ch.tryAnswer('nope', '1')).toBe(false);
+  });
+});
+
+describe('QuestionChannel.askViaQQ', () => {
+  it('attaches keyboard for single-select and sends to replyTarget', async () => {
+    const sent: SentMessage[] = [];
+    const sender = createSender(sent);
+    const ch = new QuestionChannel(createManager(), sender, { requireMention: true }, createLogger());
+    const p = startAsk(ch, 's1', [q2()]);
+    await sleep(20);
+    expect(sent[0]?.opts?.keyboard).toBeDefined();
+    expect(sent[0]?.text).toContain('点击下方按钮选择');
+    expect(sender.sendMarkdown).toHaveBeenCalledWith(makeRecord('s1').replyTarget, expect.any(String), expect.any(Object));
+    ch.tryAnswer('s1', '1');
+    await p;
+  });
+
+  it('falls back to plain text when keyboard send fails', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent, { failKeyboard: true }), { requireMention: false }, createLogger());
+    const p = startAsk(ch, 's6', [q2()]);
+    await sleep(20);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.opts).toBeUndefined();
+    expect(sent[0]?.text).toContain('回复编号选择');
+    ch.tryAnswer('s6', '1');
+    await p;
+  });
+
+  it('rejects when the question cannot be delivered at all', async () => {
+    const ch = new QuestionChannel(
+      createManager(),
+      { sendMarkdown: vi.fn(async () => { throw new Error('network down'); }) },
+      { requireMention: false },
+      createLogger(),
+    );
+    await expect(ch.askViaQQ(makeRecord('sx'), { questions: [q2()] }))
+      .rejects.toThrow('failed to deliver question to QQ');
+  });
+
+  it('rejects on abort signal', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const ac = new AbortController();
+    const p = startAsk(ch, 'sa', [q2()], 'c2c', ac.signal);
+    await sleep(20);
+    ac.abort();
+    await expect(p).rejects.toThrow('aborted');
+  });
+
+  it('supersedes a previous pending question for the same session', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const p1 = startAsk(ch, 'sk', [q2()]);
+    p1.catch(() => {}); // 抑制被取代时的未处理 rejection（下方用 rejects 断言）
+    await sleep(20);
+    const p2 = startAsk(ch, 'sk', [q2()]);
+    await sleep(20);
+    await expect(p1).rejects.toThrow('superseded');
+    ch.tryAnswer('sk', '1');
+    await p2;
+  });
+});
+
+describe('QuestionChannel.handleInteraction', () => {
+  function makeEvent(data: string | undefined, peer: { user?: string; group?: string }): InteractionEvent {
+    return {
+      id: 'i1',
+      type: 1,
+      version: 1,
+      ...(peer.group ? { group_openid: peer.group } : {}),
+      ...(peer.user ? { user_openid: peer.user } : {}),
+      data: { type: 1, resolved: { ...(data !== undefined ? { button_data: data } : {}) } },
+    } as InteractionEvent;
+  }
+
+  it('answers a c2c question by button click', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const p = startAsk(ch, 'qqbot:app:c2c:U1', [q2()]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ i: 1 }), { user: 'U1' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['B'] }] });
+  });
+
+  it('routes group clicks by group_openid', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const p = startAsk(ch, 'qqbot:app:group:G1', [q2()], 'group');
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ i: 0 }), { user: 'someone', group: 'G1' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['A'] }] });
+  });
+
+  it('resolves with the full original label for truncated buttons', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const long = '这是一个非常非常长的选项标签超过十八个字符的限制了吧';
+    const p = startAsk(ch, 'qqbot:app:c2c:U7', [{ id: 'q', question: 't', options: [{ label: long }] }]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ i: 0 }), { user: 'U7' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: [long] }] });
+  });
+
+  it('rejects malformed or stale clicks without consuming the question', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, createLogger());
+    const p = startAsk(ch, 'qqbot:app:c2c:U2', [q2()]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent('not-json', { user: 'U2' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ i: 9 }), { user: 'U2' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ i: 0 }), { user: 'nobody' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(undefined, { user: 'U2' }))).toBe(false);
+    ch.tryAnswer('qqbot:app:c2c:U2', '1'); // 文本仍可作答
+    await p;
+  });
+});
+
+describe('QuestionChannel.install routing', () => {
+  it('routes QQ sessions to QQ channel and delegates others', async () => {
+    const sent: SentMessage[] = [];
+    const record = makeRecord('qqbot:app:c2c:u9');
+    (record as { sessionId?: string }).sessionId = 'sess-qq';
+    const manager = createManager((id) => (id === 'sess-qq' ? record : undefined));
+    const ch = new QuestionChannel(manager, createSender(sent), { requireMention: false }, createLogger());
+    let origCalled = 0;
+    const uq = { ask: vi.fn(async () => { origCalled += 1; return { answers: [] }; }) };
+    ch.install({ get: (n: string) => (n === 'userQuestions' ? uq : undefined) });
+
+    await uq.ask({ questions: [q2('x')], agent: { id: 'sess-web' } });
+    expect(origCalled).toBe(1);
+
+    const p = uq.ask({ questions: [q2()], agent: { id: 'sess-qq' } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ch.tryAnswer('qqbot:app:c2c:u9', '1')).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['A'] }] });
+    expect(origCalled).toBe(1); // QQ 路径未触碰原实现
+  });
+
+  it('uninstall restores the original ask', async () => {
+    const sent: SentMessage[] = [];
+    const record = makeRecord('qqbot:app:c2c:u9');
+    const manager = createManager((id) => (id === 'sess-qq' ? record : undefined));
+    const ch = new QuestionChannel(manager, createSender(sent), { requireMention: false }, createLogger());
+    const uq: { ask: (r: UserQuestionRequest) => Promise<UserQuestionResult>; __qqQuestionPatched?: boolean } = {
+      ask: async () => ({ answers: [] }),
+    };
+    ch.install({ get: (n: string) => (n === 'userQuestions' ? uq : undefined) });
+    expect(uq.__qqQuestionPatched).toBe(true);
+    ch.uninstall();
+    expect(uq.__qqQuestionPatched).toBeUndefined();
+  });
+
+  it('disables gracefully when the userQuestions service is missing', () => {
+    const sent: SentMessage[] = [];
+    const logger = createLogger();
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false }, logger);
+    ch.install({ get: () => undefined });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/src/features/question-channel.ts
+++ b/src/features/question-channel.ts
@@ -1,0 +1,371 @@
+/**
+ * QuestionChannel — ask_user_question 的 QQ 交互通道
+ *
+ * 背景：`ask_user_question` 工具通过 `ctx.userQuestions` 的单一 provider 等待
+ * 人类回答；宿主默认 provider（dsh-host-apiproxy）把问题推给 Web 客户端渲染成
+ * 弹出框。QQ 是纯文本通道，QQ 用户原本看不到问题、也无法作答。
+ *
+ * 本通道包装 `ctx.userQuestions` 服务的 `ask` 方法（不动 provider 注册机制）：
+ *   - 提问会话属于 QQ bot（SessionManager 能按 sessionId 找到记录）→
+ *     将问题渲染为编号选项文本发到 QQ（单选带选项时附带可点击的内联按钮），
+ *     并把该会话的下一条入站文本消息或按钮点击解析为答案；
+ *   - 其他会话 → 原样委托给原 `ask`（Web 弹出框行为不变）。
+ *
+ * 按钮链路：`sendMarkdown(..., { keyboard })` 附带 `action.type=1`（回调）按钮；
+ * 用户点击触发 `interaction` 事件，由 bootstrap 的监听器转给 `handleInteraction`，
+ * 按 `button_data` 解析出所选选项并 ACK（平台要求 5 秒内）。按钮发送失败
+ * （如机器人无按钮权限）自动回退为纯文本编号问答。
+ *
+ * 平台实测结论（与部分文档/示例不一致，见注释内标注）：
+ *   - `action.type`：0=跳转链接，1=回调（点击即发 INTERACTION_CREATE），
+ *     2=把 data 填入输入框（需用户手动发送）。要实现"点击即确认"必须用 1。
+ *   - `action.permission.type`：0 在部分机器人上点击报"无权限操作"；
+ *     2（指定用户不可点，列表为空即全员可点）行为正常。
+ *
+ * 答案契约与宿主一致：`{ answers: [{ id, selected: string[], custom? }] }`，
+ * selected 使用选项的原文 label。
+ */
+import type { InlineKeyboard, InteractionEvent } from '@tencent-connect/qqbot-nodejs';
+import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+
+// ── user-questions 契约（结构化类型，避免硬依赖 dsh-user-questions） ──
+
+export interface UserQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface UserQuestion {
+  id: string;
+  question: string;
+  header?: string;
+  options?: UserQuestionOption[];
+  multiSelect?: boolean;
+}
+
+export interface UserQuestionAnswer {
+  id: string;
+  selected: string[];
+  custom?: string;
+}
+
+export interface UserQuestionRequest {
+  questions: UserQuestion[];
+  agent?: { id: string };
+  signal?: AbortSignal;
+}
+
+export interface UserQuestionResult {
+  answers: UserQuestionAnswer[];
+}
+
+export interface UserQuestionsServiceLike {
+  ask(request: UserQuestionRequest): Promise<UserQuestionResult>;
+}
+
+// ── 依赖的最小结构（SessionManager / QQBotSender 均结构化满足） ──
+
+export interface QuestionSessionRecordLike {
+  sessionKey: string;
+  scope: ChatScope;
+  replyTarget: ReplyTarget;
+}
+
+export interface QuestionChannelManagerLike {
+  findBySessionId(sessionId: string): QuestionSessionRecordLike | undefined;
+  sessionKey(scope: ChatScope, peerId: string): string;
+}
+
+export interface QuestionChannelSenderLike {
+  sendMarkdown(target: ReplyTarget, content: string, opts?: { keyboard?: InlineKeyboard }): Promise<unknown>;
+}
+
+export interface QuestionChannelConfigLike {
+  requireMention: boolean;
+}
+
+interface PendingEntry {
+  request: UserQuestionRequest;
+  resolve: (result: UserQuestionResult) => void;
+  reject: (err: Error) => void;
+  onAbort?: () => void;
+}
+
+/** QQ 按钮 label 有长度限制，超长截断（正文保留完整文本） */
+const BUTTON_LABEL_MAX = 18;
+
+function buttonLabel(text: string | undefined): string {
+  const s = String(text ?? '').trim();
+  return s.length > BUTTON_LABEL_MAX ? s.slice(0, BUTTON_LABEL_MAX - 1) + '…' : s;
+}
+
+/**
+ * 为"单题、单选、带选项"的问题构建内联键盘；不适用时返回 undefined。
+ * button_data 编码 `{"i":<选项下标>}`，由 handleInteraction 解码。
+ */
+export function buildKeyboard(questions: readonly UserQuestion[]): InlineKeyboard | undefined {
+  if (questions.length !== 1) return undefined;
+  const q = questions[0];
+  if (!q) return undefined;
+  const opts = q.options ?? [];
+  if (opts.length === 0 || q.multiSelect) return undefined;
+  return {
+    content: {
+      rows: opts.map((o, i) => ({
+        buttons: [{
+          id: `q-opt-${i}`,
+          render_data: {
+            label: buttonLabel(o.label),
+            visited_label: buttonLabel(o.label),
+            style: 1,
+          },
+          action: {
+            // action.type：0=跳转链接，1=回调（点击即发 INTERACTION_CREATE，
+            //   无需再发送），2=把 data 填入输入框（需用户手动发送）。
+            //   这里必须用 1 才能"点击即确认"。
+            type: 1,
+            // permission.type 用 2（指定用户不可点、列表为空即全员可点）；
+            // 实测 type 0 会导致点击报"无权限操作"。
+            permission: { type: 2 },
+            data: JSON.stringify({ i }),
+          },
+        }],
+      })),
+    },
+  };
+}
+
+/** 把请求中的问题渲染成 QQ 文本 */
+export function formatQuestions(
+  questions: readonly UserQuestion[],
+  requireMentionHint: boolean,
+  withButtons: boolean,
+): string {
+  const lines: string[] = [];
+  for (const q of questions) {
+    if (q.header) lines.push(`**${q.header}**`);
+    lines.push(q.question);
+    const opts = q.options ?? [];
+    opts.forEach((o, i) => {
+      lines.push(`${i + 1}. ${o.label}${o.description ? ` — ${o.description}` : ''}`);
+    });
+    if (q.multiSelect && opts.length > 0) lines.push('（可多选：回复多个编号，如 1,3）');
+  }
+  if ((questions[0]?.options?.length ?? 0) > 0) {
+    lines.push('');
+    const mention = requireMentionHint ? '（需 @机器人）' : '';
+    if (withButtons) lines.push(`点击下方按钮选择${mention}，或直接输入文字作为自定义回答。`);
+    else lines.push(`回复编号选择${mention}，或直接输入文字作为自定义回答。`);
+  }
+  return lines.join('\n');
+}
+
+/** 把用户的 QQ 文本回复解析为答案（单题精确解析；多题降级为整段文字） */
+export function parseAnswers(questions: readonly UserQuestion[], text: string): UserQuestionAnswer[] {
+  if (questions.length === 1) {
+    const q = questions[0];
+    if (!q) return [];
+    const opts = q.options ?? [];
+    if (opts.length > 0) {
+      // 纯数字/分隔符 → 按编号选择
+      if (/^[\d\s,，、;；./]+$/.test(text)) {
+        const nums = [...text.matchAll(/\d+/g)]
+          .map((m) => parseInt(m[0], 10))
+          .filter((n) => n >= 1 && n <= opts.length);
+        if (nums.length > 0) {
+          const picked = q.multiSelect ? nums : nums.slice(0, 1);
+          const selected = [...new Set(picked.map((n) => opts[n - 1]?.label).filter((l): l is string => typeof l === 'string'))];
+          return [{ id: q.id, selected }];
+        }
+      }
+      // 文本与某个选项 label 完全一致（忽略大小写）
+      const exact = opts.find((o) => o.label.toLowerCase() === text.toLowerCase());
+      if (exact) return [{ id: q.id, selected: [exact.label] }];
+    }
+    return [{ id: q.id, selected: [], custom: text }];
+  }
+  // 多问题：把整段回复作为每个问题的自定义回答（agent 自行解读）
+  return questions.map((q) => ({ id: q.id, selected: [], custom: text }));
+}
+
+export class QuestionChannel {
+  /** sessionKey → pending entry */
+  private readonly pending = new Map<string, PendingEntry>();
+  private uq: (UserQuestionsServiceLike & { __qqQuestionPatched?: boolean }) | undefined;
+  private origAsk: ((request: UserQuestionRequest) => Promise<UserQuestionResult>) | undefined;
+
+  public constructor(
+    private readonly manager: QuestionChannelManagerLike,
+    private readonly sender: QuestionChannelSenderLike,
+    private readonly config: QuestionChannelConfigLike,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * 安装：包装 userQuestions 服务的 `ask` 方法。
+   *
+   * 选择包装 `ask` 而非替换 `provider`：
+   *   - provider 注册在宿主的 effect 里延迟赋值且查重（DUPLICATE_PROVIDER），
+   *     直接换 provider 会受插件加载顺序影响、甚至引发冲突；
+   *   - `ask` 是服务实例方法，工具/计划模式都经 `ctx.userQuestions.ask(...)` 调用，
+   *     在实例上覆写即可稳定拦截，且非 QQ 会话原样委托给原实现（Web 弹出框不受影响）。
+   */
+  install(ctx: { get(name: string): unknown }): void {
+    let uq: (UserQuestionsServiceLike & { __qqQuestionPatched?: boolean }) | undefined;
+    try {
+      const svc = ctx.get('userQuestions') as UserQuestionsServiceLike | undefined;
+      if (svc && typeof svc.ask === 'function') uq = svc as UserQuestionsServiceLike & { __qqQuestionPatched?: boolean };
+    } catch {
+      uq = undefined;
+    }
+    if (!uq) {
+      this.logger.warn('im-qqbot: userQuestions service unavailable; QQ question channel disabled');
+      return;
+    }
+    if (uq.__qqQuestionPatched) {
+      this.logger.warn('im-qqbot: userQuestions already patched; skipping duplicate install');
+      return;
+    }
+    const self = this;
+    const origAsk = uq.ask.bind(uq);
+    uq.ask = async function qqRoutedAsk(request: UserQuestionRequest): Promise<UserQuestionResult> {
+      const sessionId = request?.agent?.id;
+      const record = sessionId ? self.manager.findBySessionId(sessionId) : undefined;
+      if (record) return self.askViaQQ(record, request);
+      return origAsk(request);
+    };
+    uq.__qqQuestionPatched = true;
+    this.uq = uq;
+    this.origAsk = origAsk;
+    this.logger.info('im-qqbot: QQ question channel installed (ask-wrap)');
+  }
+
+  /** 卸载：恢复原 `ask`，拒绝所有待答问题 */
+  uninstall(): void {
+    if (this.uq && this.origAsk) {
+      this.uq.ask = this.origAsk;
+      delete this.uq.__qqQuestionPatched;
+      this.uq = undefined;
+      this.origAsk = undefined;
+    }
+    for (const [, entry] of this.pending) {
+      entry.reject(new Error('QQ question channel was unloaded before the user answered'));
+    }
+    this.pending.clear();
+  }
+
+  /**
+   * 入站截获：该会话若有待答问题且本条消息有文本，解析为答案并提交。
+   * @returns true 表示消息已被消费为答案（调用方应停止常规处理）
+   */
+  tryAnswer(sessionKey: string, text: string): boolean {
+    const entry = this.pending.get(sessionKey);
+    if (!entry) return false;
+    if (!text) return false; // 纯图片/表情等：继续等待，消息走常规流程
+    this.pending.delete(sessionKey);
+    if (entry.onAbort && entry.request.signal) {
+      entry.request.signal.removeEventListener('abort', entry.onAbort);
+    }
+    let answers: UserQuestionAnswer[];
+    try {
+      answers = parseAnswers(entry.request.questions, text);
+    } catch (err) {
+      entry.reject(err instanceof Error ? err : new Error(String(err)));
+      return true;
+    }
+    this.logger.info(`im-qqbot: question answered via QQ key=${sessionKey} text="${text.slice(0, 80)}"`);
+    entry.resolve({ answers });
+    return true;
+  }
+
+  /** QQ 通道提问：发送编号选项文本（单选附带可点击按钮），等待回复或按钮点击 */
+  async askViaQQ(record: QuestionSessionRecordLike, request: UserQuestionRequest): Promise<UserQuestionResult> {
+    const key = record.sessionKey;
+    // 同会话已有待答问题（理论上不会发生：回合阻塞在第一个问题上）→ 拒绝旧的
+    const prev = this.pending.get(key);
+    if (prev) {
+      this.pending.delete(key);
+      prev.reject(new Error('superseded by a new question'));
+    }
+    const hint = record.scope === 'group' && this.config.requireMention === true;
+    const keyboard = buildKeyboard(request.questions);
+    const text = formatQuestions(request.questions, hint, keyboard !== undefined);
+    try {
+      if (keyboard !== undefined) {
+        try {
+          await this.sender.sendMarkdown(record.replyTarget, text, { keyboard });
+        } catch (kbErr) {
+          // 按钮发送失败（常见：机器人无按钮权限）→ 回退纯文本编号问答（重排提示语）
+          this.logger.warn(`im-qqbot: keyboard send failed, fallback to text: ${kbErr instanceof Error ? kbErr.message : String(kbErr)}`);
+          await this.sender.sendMarkdown(record.replyTarget, formatQuestions(request.questions, hint, false));
+        }
+      } else {
+        await this.sender.sendMarkdown(record.replyTarget, text);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`im-qqbot: question send failed key=${key}: ${msg}`);
+      throw new Error(`failed to deliver question to QQ: ${msg}`);
+    }
+    return new Promise<UserQuestionResult>((resolve, reject) => {
+      const entry: PendingEntry = { request, resolve, reject };
+      if (request.signal) {
+        const onAbort = (): void => {
+          if (this.pending.get(key) !== entry) return;
+          this.pending.delete(key);
+          reject(new Error('ask_user_question was aborted before the user answered'));
+        };
+        entry.onAbort = onAbort;
+        request.signal.addEventListener('abort', onAbort, { once: true });
+      }
+      this.pending.set(key, entry);
+      this.logger.info(`im-qqbot: question sent to QQ (${keyboard !== undefined ? 'with buttons' : 'text only'}), waiting for answer key=${key}`);
+    });
+  }
+
+  /**
+   * 按钮点击回调：按事件来源定位会话，解码 button_data 提交答案。
+   * @returns true 表示点击命中了一个待答问题（调用方据此选择 ACK 结果）
+   */
+  handleInteraction(event: InteractionEvent): boolean {
+    const raw = event?.data?.resolved?.button_data;
+    if (typeof raw !== 'string' || raw.length === 0) {
+      this.logger.warn('im-qqbot: interaction without button_data ignored');
+      return false;
+    }
+    const peerId = event.group_openid ?? event.user_openid;
+    if (!peerId) {
+      this.logger.warn('im-qqbot: interaction without peer openid ignored');
+      return false;
+    }
+    const scope: ChatScope = event.group_openid ? 'group' : 'c2c';
+    const key = this.manager.sessionKey(scope, peerId);
+    const entry = this.pending.get(key);
+    if (!entry) {
+      this.logger.warn(`im-qqbot: button click with no pending question key=${key}`);
+      return false;
+    }
+    let idx: unknown;
+    try {
+      idx = (JSON.parse(raw) as { i?: unknown }).i;
+    } catch {
+      this.logger.warn(`im-qqbot: unparseable button_data="${raw}"`);
+      return false;
+    }
+    const q = entry.request.questions?.[0];
+    const opts = q?.options ?? [];
+    if (typeof idx !== 'number' || !opts[idx]) {
+      this.logger.warn(`im-qqbot: button index out of range idx=${String(idx)} options=${opts.length}`);
+      return false;
+    }
+    const option = opts[idx];
+    if (!option || !q) return false;
+    this.pending.delete(key);
+    if (entry.onAbort && entry.request.signal) {
+      entry.request.signal.removeEventListener('abort', entry.onAbort);
+    }
+    this.logger.info(`im-qqbot: question answered via QQ button key=${key} option=${option.label}`);
+    entry.resolve({ answers: [{ id: q.id, selected: [option.label] }] });
+    return true;
+  }
+}

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -17,6 +17,7 @@ import type { Logger } from '../types.js';
 import { setupMiddlewares } from './middleware-setup.js';
 import { startMediaCleanup } from '../media/media-cleaner.js';
 import { ensureVisionInputModal, registerDescribeImageTool } from '../media/vision-tool.js';
+import { QuestionChannel } from '../features/question-channel.js';
 
 export async function bootstrapGateway(
   ctx: Context,
@@ -61,8 +62,9 @@ export async function bootstrapGateway(
   }
 
   // 发送适配器：将 QQBot 实例适配为 QQBotSender（openStream 参数形态不同）
+  // sendMarkdown 透传 opts（承载 { keyboard } 内联按钮，交互式提问用）
   const sender: QQBotSender = {
-    sendMarkdown: (target, content) => bot.sendMarkdown(target, content),
+    sendMarkdown: (target, content, opts) => bot.sendMarkdown(target, content, opts),
     openStream: (target) => bot.openStream({
       target: {
         scope: target.scope,
@@ -75,6 +77,28 @@ export async function bootstrapGateway(
   const outboundHandler = createOutboundHandler(manager, sender, config, logger, toolsRegistry);
   (ctx as unknown as { on(event: string, handler: (...args: unknown[]) => void): void })
     .on('session/event', outboundHandler as (...args: unknown[]) => void);
+
+  // ── 交互式提问通道：QQ 会话的 ask_user_question 渲染为文本/按钮，回复即答案 ──
+  const questionChannel = new QuestionChannel(manager, sender, config, logger);
+  questionChannel.install(ctx as unknown as { get(name: string): unknown });
+  manager.questionChannel = questionChannel;
+
+  // ── 按钮点击回调：解析为答案（平台要求 5 秒内 ACK） ──
+  bot.on('interaction', async (_iCtx, event) => {
+    logger.info(`im-qqbot: interaction received id=${event?.id ?? '-'} button=${event?.data?.resolved?.button_id ?? '-'} data=${event?.data?.resolved?.button_data ?? '-'} from=${event?.group_openid ? 'group:' + event.group_openid : 'c2c:' + (event?.user_openid ?? '-')}`);
+    let matched = false;
+    try {
+      matched = questionChannel.handleInteraction(event);
+    } catch (err) {
+      logger.error(`im-qqbot: interaction handling failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    try {
+      await bot.acknowledgeInteraction(event.id, matched ? 0 : 3);
+      logger.info(`im-qqbot: interaction acked id=${event?.id ?? '-'} matched=${matched}`);
+    } catch (err) {
+      logger.error(`im-qqbot: interaction ack failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  });
 
   bot.on('error', (err: unknown) => {
     logger.error(`bot error: ${err instanceof Error ? err.message : String(err)}`);
@@ -103,6 +127,7 @@ export async function bootstrapGateway(
 
       return async () => {
         logger.info('Shutting down');
+        questionChannel.uninstall();
         await manager.disposeAll();
         bot.stop();
       };

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -20,6 +20,7 @@ import type { ImQQBotConfig } from '../config.js';
 import { ModelResolver } from '../model/model-resolver.js';
 import type { ModelRoute, ModelEntry } from '../model/types.js';
 import { IdleEvictor } from './idle-evictor.js';
+import type { QuestionChannel } from '../features/question-channel.js';
 import type {
   SessionEventLike,
   DshAgent,
@@ -48,6 +49,8 @@ export class SessionManager {
   private sessions = new Map<string, SessionRecord>();
   private readonly evictor: IdleEvictor;
   private readonly modelResolver: ModelResolver;
+  /** 交互式提问通道（由 bootstrap 注入；入站消息据此截获"问题回答"） */
+  questionChannel?: QuestionChannel;
 
   constructor(
     private readonly ctx: Context,
@@ -239,7 +242,7 @@ export class SessionManager {
 
   // ── Session 生命周期管理 ──
 
-  private sessionKey(scope: ChatScope, peerId: string): string {
+  sessionKey(scope: ChatScope, peerId: string): string {
     return `qqbot:${this.config.appId}:${scope}:${peerId}`;
   }
 

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -103,6 +103,14 @@ export async function handleInbound(
     msgId: msg.messageId,
   };
 
+  // ── 交互式提问通道：该会话有待答问题时，本条文本消息即答案 ──
+  //    （contentSanitizer 已剥离 @标记；斜杠命令在中间件层已被拦截，不会到这里）
+  const questionChannel = manager.questionChannel;
+  if (questionChannel && questionChannel.tryAnswer(manager.sessionKey(scope, peerId), (msg.content ?? '').trim())) {
+    logger.info(`Question answered via QQ: scope=${scope} peerId=${peerId}`);
+    return;
+  }
+
   // ── 组装 agentBody（下载结果经 mwState.downloadedFiles 提供） ──
   const agentBody = assembleAgentBody(msg, mwState, scope, logger);
 

--- a/src/transport/outbound-buffer.ts
+++ b/src/transport/outbound-buffer.ts
@@ -4,6 +4,7 @@
  * 收集流式 chunk，流式优先投递（StreamingWriter），降级为静态发送。
  * 独立文件便于单测。
  */
+import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
 import type { SessionRecord } from '../session/index.js';
 import type { Logger, ReplyTarget } from '../types.js';
 import { chunkMarkdownText } from './chunker.js';
@@ -20,7 +21,8 @@ export interface StreamSessionLike {
 
 /** QQ Bot 发送接口 */
 export interface QQBotSender {
-  sendMarkdown(target: ReplyTarget, content: string): Promise<unknown>;
+  /** opts.keyboard 附带内联按钮（交互式提问用，透传给平台） */
+  sendMarkdown(target: ReplyTarget, content: string, opts?: { keyboard?: InlineKeyboard }): Promise<unknown>;
   openStream(target: ReplyTarget): StreamSessionLike;
 }
 


### PR DESCRIPTION
## 背景

`ask_user_question` 工具通过 `ctx.userQuestions` 的单一 provider 等待人类回答；宿主默认 provider（dsh-host-apiproxy）把问题推给 **Web 客户端**渲染成弹出框。QQ 是纯文本通道，QQ 用户原本看不到问题、也无法作答，agent 会一直阻塞等待。

## 方案

新增 `QuestionChannel`（`src/features/question-channel.ts`），**包装 `userQuestions` 服务的 `ask` 方法**（不动 provider 注册机制，避免 `DUPLICATE_PROVIDER` 冲突和插件加载顺序依赖）：

- **QQ 会话**（SessionManager 能按 `agent.id` 找到记录）→ 问题渲染为编号选项文本发到 QQ；**其他会话原样委托给原 `ask`**，Web 弹出框行为完全不受影响。
- **单题单选带选项**时随文本附带内联键盘按钮，**点击即作答**；多选/多题/无选项走纯文本。
- **文本作答**：待答会话的下一条入站文本消息被截获，按 `编号 / 选项原文 / 自定义文字` 解析为答案（答案契约与宿主一致：`{ answers: [{ id, selected, custom? }] }`，selected 为选项原文）。
- **按钮作答**：`interaction` 事件按 `button_data` 解析出选项并立即确认，5 秒内 ACK（平台要求）；未命中的点击 ACK code 3。
- **降级**：按钮发送失败（如机器人未开通按钮权限）自动回退为纯文本编号问答，并重排提示语。
- 问题被中止（abort）/ 被新问题取代 / 通道卸载时，pending 正确清理或拒绝。

## 平台实测结论（与部分文档/示例不一致，已验证）

本 PR 的按钮参数在真实 QQ 机器人上逐项验证通过：

| 参数 | 实测结论 |
| --- | --- |
| `action.type` | **0**=跳转链接，**1**=回调（点击即发 `INTERACTION_CREATE`），**2**=把 data 填入输入框（需用户手动发送）。"点击即确认"必须用 **1** —— `qqbot-nodejs` USAGE.md §9.2 示例标注的 `type: 2` 实为输入框模式 |
| `action.permission.type` | 用 **2**（指定用户不可点、列表为空即全员可点）行为正常；**0** 在部分机器人上点击报"无权限操作" |

## 改动清单

- `src/features/question-channel.ts` — 核心模块（渲染/键盘构建/文本解析/按钮回调/安装卸载）
- `src/features/question-channel.test.ts` — 28 个 vitest 用例
- `src/gateway/bootstrap.ts` — sender 透传 `{ keyboard }`、通道安装、`interaction` 监听与 ACK、关闭时卸载
- `src/transport/inbound.ts` — 待答会话的文本答案截获
- `src/transport/outbound-buffer.ts` — `QQBotSender.sendMarkdown` 增加可选 `opts`
- `src/session/session-manager.ts` — 暴露 `sessionKey`、挂载 `questionChannel`
- `README.md` / `CHANGELOG.md` — 文档

## 验证

- `tsc` 无错误；`vitest run` 全量 **42 通过**（含既有 14 个用例）
- 真实 QQ 机器人端到端验证：文本编号作答、按钮点击即确认（无需二次发送）、多选回退、无按钮权限回退均已通过
