### PR TITLE
feat(commands): add /preset command for switching agent presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 | `/new`（别名 `/reset` `/clear`） | 开始新会话（清空上下文） |
 | `/compact` | 压缩会话历史（摘要替换旧记录，保留上下文） |
 | `/model` | 查看或切换模型 |
+| `/preset` | 查看或切换 agent preset（新会话生效） |
 | `/stop` | 中止当前生成 |
 | `/bot-ping` | 连通性测试 |
 | `/bot-version` | 查看版本信息 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -77,6 +77,7 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 | `/new` (aliases `/reset` `/clear`) | Start a new session (clear context) |
 | `/compact` | Compact session history (replace old records with a summary) |
 | `/model` | View or switch model |
+| `/preset` | View or switch agent preset (applies to new sessions) |
 | `/stop` | Abort the current generation |
 | `/bot-ping` | Connectivity test |
 | `/bot-version` | View version info |

--- a/cordis.yml
+++ b/cordis.yml
@@ -8,6 +8,7 @@
 #   DEEPSEEK_API_KEY - DeepSeek API Key
 #   DSH_CWD         - Agent 工作目录（可选）
 #   HUNYUAN_API_KEY - 视觉模型 API Key（qqbot_describe_image 工具，hunyuan-vision）
+#   DSH_PRESET_ROOT - 系统预置 preset 目录（可选，默认 ./apps/cli/config/agent-presets）
 
 # ── 核心 spine ──
 - id: sessions
@@ -24,6 +25,17 @@
 
 - id: tools
   name: '@deepseek-ai/dsh-tools'
+
+# ── Agent Preset 服务（/preset 命令切换 preset 依赖） ──
+- id: agent-presets
+  name: '@deepseek-ai/dsh-agent-presets'
+  config:
+    default: standard
+    roots:
+      # 系统预置 preset 目录（deepseek-harness 的 apps/cli/config/agent-presets，含 standard/code/cordis/minimal）
+      - path: ${DSH_PRESET_ROOT:-./apps/cli/config/agent-presets}
+        trust: system
+    # includeUserRoot 默认 true：额外加载 $DSH_HOME/.agent-presets（用户自定义 preset）
 
 # ── 附件存储（describe_image 工具的 attachments.saveImage 依赖） ──
 - id: attachment-local

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,8 +1,7 @@
 /**
  * 斜杠命令注册中心
  *
- * 每个命令拆分为独立文件，此处仅编排。参考 openclaw-qqbot 的
- * commands/index.ts 模式：工厂函数注入依赖，统一导出命令列表。
+ * 每个命令拆分为独立文件，此处仅编排。工厂函数注入依赖，统一导出命令列表。
  *
  * 命令按 category 分两类：
  *   - agent：底层 dsh agent 通用能力（new/compact/model/stop）
@@ -11,6 +10,7 @@
 import type { CommandDeps, CategorizedCommand } from './types.js';
 import { newCommand, compactCommand } from './session.js';
 import { modelCommand } from './model.js';
+import { presetCommand } from './preset.js';
 import { statusCommand } from './status.js';
 import { helpCommand } from './help.js';
 import { pingCommand, versionCommand, stopCommand } from './misc.js';
@@ -24,6 +24,7 @@ export function buildCommandList(deps: CommandDeps): CategorizedCommand[] {
     newCommand(deps),
     compactCommand(deps),
     modelCommand(deps),
+    presetCommand(deps),
     stopCommand(deps),
     // QQBot 特有
     pingCommand(),

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -1,0 +1,65 @@
+/**
+ * Preset 命令：/preset — 查看或切换 agent preset
+ *
+ * 无参数列出可用 preset（可点击切换），有参数切换，reset/default 重置为默认。
+ */
+import type { CommandDeps, CategorizedCommand } from './types.js';
+import { getScopePeer, sendMarkdownChunked } from '../shared/index.js';
+
+export function presetCommand({ manager, config }: CommandDeps): CategorizedCommand {
+  return {
+    name: 'preset',
+    category: 'agent',
+    description: '查看或切换 agent preset（用法: /preset [id]）',
+    handler: async (cmdCtx) => {
+      const { scope, peerId } = getScopePeer(cmdCtx);
+      const args = (cmdCtx.command?.raw ?? '').trim();
+
+      // 无参数：列出可用 preset + 当前
+      if (!args) {
+        const presets = await manager.listPresets();
+        if (presets.length === 0) {
+          return '当前部署无可用的 agent preset';
+        }
+
+        const record = manager.getSessionRecord(scope, peerId);
+        const currentId = record?.agentPreset ?? manager.getEffectivePreset(scope, peerId);
+
+        const lines: string[] = ['### 🧩 Agent Preset', ''];
+        lines.push(`**当前:** ${currentId ?? '默认'}`);
+        lines.push('', '**可用 preset（点击切换）:**');
+        for (const p of presets) {
+          const display = p.name ? `${p.name} (${p.id})` : p.id;
+          lines.push(`<qqbot-cmd-input text="/preset ${p.id}" show="/preset ${display}"/>`);
+        }
+        lines.push('', '手动指定: `/preset <id>`，重置默认: `/preset reset`');
+
+        await sendMarkdownChunked(cmdCtx, lines.join('\n'), config.textChunkLimit);
+        return { kind: 'noop' as const };
+      }
+
+      // reset / default：清除 per-peer 覆盖，回到默认
+      if (args === 'reset' || args === 'default') {
+        const outcome = await manager.clearPresetOverride(scope, peerId);
+        return outcome.ok ? '✅ 已重置为默认 preset（新会话生效）' : '重置失败';
+      }
+
+      // 切换到指定 preset
+      const outcome = await manager.setPresetOverride(scope, peerId, args);
+      if (!outcome.ok) {
+        switch (outcome.reason) {
+          case 'unavailable':
+            return '当前部署不支持 agent preset（agentPresets 服务未注入）';
+          case 'unknown-preset':
+            return `未知 preset: ${args}`;
+          case 'broken':
+            return `preset ${args} 加载失败: ${outcome.message ?? '未知错误'}`;
+          default:
+            return `切换失败: ${outcome.message ?? '未知错误'}`;
+        }
+      }
+
+      return `✅ preset 已切换: ${args}\n新会话生效（当前会话保持原 preset，发送 /new 后生效）。`;
+    },
+  };
+}

--- a/src/features/history-store.ts
+++ b/src/features/history-store.ts
@@ -3,7 +3,6 @@
  *
  * historyBuffer 中间件需要一个跨调用可访问的 HistoryStore 实例，
  * 以便在回复完成后清空某群的历史缓存（避免下次 @ 时重复组包）。
- * 对齐 openclaw-qqbot 的 features/history-store。
  */
 import { MemoryHistoryStore } from '@tencent-connect/qqbot-nodejs';
 import type { HistoryStore } from '@tencent-connect/qqbot-nodejs';

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -53,7 +53,7 @@ export async function bootstrapGateway(
   });
 
   // ── 出站：dsh session/event → QQ 消息 ──
-  // 获取 tools 服务（工具结果结构化展示，参考 dsh-TUI presentResult），可选
+  // 获取 tools 服务（工具结果结构化展示），可选
   let toolsRegistry: ToolsRegistryLike | undefined;
   try {
     toolsRegistry = ctx.get('tools') as ToolsRegistryLike | undefined;

--- a/src/media/send-file-tool.ts
+++ b/src/media/send-file-tool.ts
@@ -1,7 +1,6 @@
 /**
  * 内置 qqbot_send_file 工具 — 将本地文件发送给 QQ 用户或群。
  *
- * 参考 qqbot-cli 的 MCP send_file 工具，但适配 dsh-qqbot：
  *   - 发送目标默认自动定位（exec.agent → SessionManager.findByAgent → replyTarget），
  *     无需模型手动传 openid；显式 target 参数作为覆盖。
  *   - 按扩展名分发到 SDK 的 sendImage / sendVideo / sendVoice / sendFile。

--- a/src/media/vision-tool.ts
+++ b/src/media/vision-tool.ts
@@ -1,12 +1,11 @@
 /**
  * 内置 qqbot_describe_image 视觉工具。
  *
- * 复用 dsh 生态的 llm + attachments 服务（路线 A）：
+ * 复用 dsh 生态的 llm + attachments 服务：
  *   1. 加载图片（本地绝对路径 / http URL）→ magic bytes 嗅探 mediaType
  *   2. attachments.saveImage → ImageAttachmentRef（字节不进 session log）
  *   3. createUserMessage(ImageBlock + text) → llm.stream → BlockAssembler 收集文本
  *
- * 对齐 dsh 官方辅助 LLM 调用范式（session-title-llm）与图片入模范式（apiproxy）。
  * 手写 ToolDefinition（标准 JSON Schema），避免引入 dsh-tools 的 8 个 peer 依赖。
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
@@ -153,7 +152,7 @@ async function callVision(
   return text;
 }
 
-/** 展开 `~`/`~/`/`~\` 前缀（对齐 @deepseek-ai/dsh-home-paths 的 expandHomePath） */
+/** 展开 `~`/`~/`/`~\` 前缀 */
 function expandHomePath(path: string): string {
   if (path === '~') return homedir();
   if (path.startsWith('~/') || path.startsWith('~\\')) return join(homedir(), path.slice(2));
@@ -161,7 +160,7 @@ function expandHomePath(path: string): string {
 }
 
 /**
- * 解析 DSH_HOME（对齐 dsh 官方 resolveDshHome 的优先级与跨平台处理）：
+ * 解析 DSH_HOME 的优先级与跨平台处理：
  * 显式配置 > `$DSH_HOME`（空/空白视为未设置）> `~/.dsh`，展开 `~` 后 resolve 为绝对路径。
  */
 function resolveDshHome(): string {
@@ -175,7 +174,7 @@ function resolveDshHome(): string {
 /**
  * 启动时检查 settings.yaml 里 vision 模型的 input 模态是否声明了 image。
  *
- * webui 的模型配置界面不暴露 `input` 字段，用户通过 webui 配置的视觉模型默认是纯文本，
+ * 模型配置界面不暴露 `input` 字段，用户通过界面配置的视觉模型默认是纯文本，
  * 会导致 pi-ai adapter 拒绝图片输入。这里在启动时兜底：未声明 image 时自动补 `[text, image]`。
  * 幂等（已声明则跳过），解析/写入失败仅 warn 不阻断启动。
  */
@@ -187,7 +186,7 @@ export function ensureVisionInputModal(vision: VisionConfig, logger: Logger): vo
   try {
     if (!existsSync(settingsPath)) return;
 
-    // YAML 禁止 tab 缩进（webui/编辑器可能写入），读入时把行首 tab 规范化为空格
+    // YAML 禁止 tab 缩进（配置界面/编辑器可能写入），读入时把行首 tab 规范化为空格
     const raw = readFileSync(settingsPath, 'utf8');
     const normalized = raw.replace(/^\t+/gm, (tabs) => '  '.repeat(tabs.length));
     const doc = yaml.load(normalized) as Record<string, unknown> | null;

--- a/src/model/model-resolver.ts
+++ b/src/model/model-resolver.ts
@@ -54,12 +54,10 @@ export class ModelResolver {
    *
    * 优先级：per-peer 偏好 > cordis.yml 显式配置 > 默认链（settings.yaml > host）
    *
-   * 注意：不能像 dsh-TUI 那样返回 undefined 让 session 沿用 requestHeader。
-   * dsh-TUI 靠 installModelSelection 从 session.requestHeader 恢复 {{model}}，
-   * 而我们未装 installModelSelection，system-prompt 的 {{model}} 变量直接读
-   * agent.options.model（agent-loop index.ts:352）——若无值会抛
+   * 这里不返回 undefined，因为未装 installModelSelection，system-prompt 的
+   * {{model}} 变量直接读 agent.options.model——若无值会抛
    * "prompt variable {{model}} has no value for this assembly"。
-   * 因此这里兜底到默认链，确保 agent.options.model 始终有值。
+   * 因此兜底到默认链，确保 agent.options.model 始终有值。
    */
   getResumeRoute(sessionKey: string): ModelRoute | undefined {
     const override = this.prefs.getOverride(sessionKey);
@@ -115,6 +113,27 @@ export class ModelResolver {
   }
 
   /**
+   * 获取指定 sessionKey 的 per-peer preset 覆盖
+   */
+  getPreset(sessionKey: string): string | undefined {
+    return this.prefs.getPreset(sessionKey);
+  }
+
+  /**
+   * 设置 per-peer preset 覆盖并持久化
+   */
+  setPreset(sessionKey: string, presetId: string): void {
+    this.prefs.setPreset(sessionKey, presetId);
+  }
+
+  /**
+   * 清除 per-peer preset 覆盖并持久化
+   */
+  clearPreset(sessionKey: string): boolean {
+    return this.prefs.clearPreset(sessionKey);
+  }
+
+  /**
    * 解析默认模型路由（不含 per-peer 偏好）
    *
    * 优先级：config 显式指定 > settings.yaml（只读） > 宿主 agentDefaultModel
@@ -137,8 +156,7 @@ export class ModelResolver {
   /**
    * 列出所有可用模型
    *
-   * 优先走 ctx.llm 服务动态发现（对齐 webui 的 buildModelCatalog），
-   * 服务不可用或失败时回退 settings.yaml 静态配置。
+   * 优先走 ctx.llm 服务动态发现，服务不可用或失败时回退 settings.yaml 静态配置。
    */
   async listModels(): Promise<ModelEntry[]> {
     const llm = this.getLlmService();
@@ -155,7 +173,7 @@ export class ModelResolver {
             entries.push({ provider: providerId, id: model.id, name: model.name });
           }
         } catch (err) {
-          // 单个 provider 失败，跳过（对齐 webui 的 failures 语义）
+          // 单个 provider 失败，跳过
           this.logger?.debug(
             `ModelResolver: provider ${providerId} 模型列表获取失败: ${err instanceof Error ? err.message : String(err)}`,
           );

--- a/src/model/prefs-store.ts
+++ b/src/model/prefs-store.ts
@@ -1,5 +1,5 @@
 /**
- * PrefsStore — per-peer 模型偏好持久化
+ * PrefsStore — per-peer 会话偏好持久化（模型 + preset）
  *
  * 隔离文件 I/O 操作，便于单元测试时 mock。
  * 存储路径：~/.dsh-qqbot/model-prefs.json
@@ -17,6 +17,8 @@ interface PrefsFile {
   overrides: Record<string, ModelRoute>;
   /** sessionKey → 最新 sessionId（fork 后更新，用于重启后恢复到 fork 后的会话） */
   sessionIds: Record<string, string>;
+  /** sessionKey → preset id（per-peer preset 覆盖） */
+  presets: Record<string, string>;
 }
 
 export class PrefsStore {
@@ -24,6 +26,8 @@ export class PrefsStore {
   private overrides = new Map<string, ModelRoute>();
   /** per-peer 最新 sessionId（fork 后更新，内存态） */
   private sessionIds = new Map<string, string>();
+  /** per-peer preset 偏好（内存态） */
+  private presets = new Map<string, string>();
   /** 隔离偏好文件路径 */
   private readonly prefsPath: string;
   private readonly debugLog?: DebugFn;
@@ -72,6 +76,23 @@ export class PrefsStore {
     return deleted;
   }
 
+  // ── Preset 操作 ──
+
+  getPreset(sessionKey: string): string | undefined {
+    return this.presets.get(sessionKey);
+  }
+
+  setPreset(sessionKey: string, presetId: string): void {
+    this.presets.set(sessionKey, presetId);
+    this.write();
+  }
+
+  clearPreset(sessionKey: string): boolean {
+    const deleted = this.presets.delete(sessionKey);
+    if (deleted) this.write();
+    return deleted;
+  }
+
   // ── 私有方法 ──
 
   private load(): void {
@@ -93,6 +114,13 @@ export class PrefsStore {
           }
         }
       }
+      if (data.presets && typeof data.presets === 'object') {
+        for (const [key, presetId] of Object.entries(data.presets)) {
+          if (typeof presetId === 'string' && presetId) {
+            this.presets.set(key, presetId);
+          }
+        }
+      }
     } catch (err) {
       this.debugLog?.(`loadPrefs failed: ${err instanceof Error ? err.message : String(err)}`);
     }
@@ -104,6 +132,7 @@ export class PrefsStore {
       const data: PrefsFile = {
         overrides: Object.fromEntries(this.overrides.entries()),
         sessionIds: Object.fromEntries(this.sessionIds.entries()),
+        presets: Object.fromEntries(this.presets.entries()),
       };
       writeFileSync(this.prefsPath, JSON.stringify(data, null, 2), 'utf8');
     } catch (err) {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -14,6 +14,8 @@ export type {
   DshAgentRegistry,
   AgentPresetsLike,
   PresetComposition,
+  PresetEntry,
+  PresetSwitchOutcome,
   SessionRecord,
   SessionStatus,
   TokenUsageStats,

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -28,6 +28,8 @@ import type {
   DshAgentRegistry,
   AgentPresetsLike,
   PresetComposition,
+  PresetEntry,
+  PresetSwitchOutcome,
   SessionRecord,
   SessionStatus,
   TokenUsageStats,
@@ -35,7 +37,7 @@ import type {
   CompactOutcome,
 } from './types.js';
 
-/** ManualCompactionError 各 code 的友好提示（对齐 command-compact 的 expectedFailure 语义） */
+/** ManualCompactionError 各 code 的友好提示 */
 const COMPACTION_ERROR_HINTS: Record<string, string> = {
   busy: '压缩服务忙，请稍后重试',
   cancelled: '压缩已取消',
@@ -80,6 +82,37 @@ export class SessionManager {
     }
   }
 
+  /**
+   * 动态获取 agentPresets 服务（可选，未注入时返回 undefined）
+   */
+  private getPresetsService(): AgentPresetsLike | undefined {
+    try {
+      return this.ctx.get('agentPresets') as AgentPresetsLike | undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * 从 session 持久化 header 读 session 当初的 preset（started 锁定语义）。
+   * 读不到（服务缺失 / session 不存在 / 未记录 agentPreset）返回 undefined。
+   */
+  private async resolvePersistedPreset(sessionId: string): Promise<string | undefined> {
+    let persistence: { load(id: string): Promise<{ meta?: { agentPreset?: string } }> } | undefined;
+    try {
+      persistence = this.ctx.get('sessionPersistence') as typeof persistence | undefined;
+    } catch {
+      return undefined;
+    }
+    if (!persistence) return undefined;
+    try {
+      const { meta } = await persistence.load(sessionId);
+      return meta?.agentPreset;
+    } catch {
+      return undefined;
+    }
+  }
+
   // ── 模型相关（委托给 ModelResolver） ──
 
   getEffectiveModel(scope: ChatScope, peerId: string): ModelRoute | undefined {
@@ -87,7 +120,34 @@ export class SessionManager {
   }
 
   /**
-   * 切换模型（fork + 重建，对齐 dsh-TUI 的 switchModel）
+   * 获取指定 peer 的生效 preset（per-peer 覆盖 > config.preset）
+   */
+  getEffectivePreset(scope: ChatScope, peerId: string): string | undefined {
+    return this.getEffectivePresetByKey(this.sessionKey(scope, peerId));
+  }
+
+  /** 按 sessionKey 解析生效 preset */
+  private getEffectivePresetByKey(key: string): string | undefined {
+    return this.modelResolver.getPreset(key) ?? this.config.preset;
+  }
+
+  /**
+   * 列出所有可用 preset（/preset 命令用）
+   */
+  async listPresets(): Promise<PresetEntry[]> {
+    const presets = this.getPresetsService();
+    if (!presets) return [];
+    try {
+      const list = await presets.list();
+      return list.map((p) => ({ id: p.id, name: p.name, description: p.description }));
+    } catch (err) {
+      this.logger.warn(`list presets failed: ${err instanceof Error ? err.message : String(err)}`);
+      return [];
+    }
+  }
+
+  /**
+   * 切换模型（fork + 重建会话，保留历史）
    */
   async setModelOverride(scope: ChatScope, peerId: string, route: ModelRoute): Promise<void> {
     const key = this.sessionKey(scope, peerId);
@@ -99,6 +159,64 @@ export class SessionManager {
       this.logger.info(`model pref saved (no active session): key=${key} → ${route.provider}/${route.model}`);
       return;
     }
+
+    await this.rebuildSession(record, { route });
+    this.logger.info(`model switched via fork: key=${key} → ${route.provider}/${route.model}`);
+  }
+
+  /**
+   * 切换指定 peer 的 agent preset（per-peer 覆盖）
+   *
+   * 已开始的会话保持锁定（blank-session contract）：只持久化为新会话默认，
+   * 不 fork/rebuild 当前会话，避免历史工具调用与新 preset 工具集冲突。
+   */
+  async setPresetOverride(scope: ChatScope, peerId: string, presetId: string): Promise<PresetSwitchOutcome> {
+    const key = this.sessionKey(scope, peerId);
+
+    // 1. 校验 preset 存在 + 可加载（broken 拒绝）
+    const presets = this.getPresetsService();
+    if (!presets) return { ok: false, reason: 'unavailable' };
+    let resolved: { id: string; broken?: string };
+    try {
+      resolved = await presets.resolve(presetId);
+    } catch (err) {
+      return { ok: false, reason: 'unknown-preset', message: err instanceof Error ? err.message : String(err) };
+    }
+    if (resolved.broken !== undefined) {
+      return { ok: false, reason: 'broken', message: resolved.broken };
+    }
+
+    // 2. 持久化 per-peer 覆盖（新会话生效）
+    this.modelResolver.setPreset(key, presetId);
+
+    const hasActive = this.sessions.has(key);
+    this.logger.info(
+      `preset pref saved: key=${key} → ${presetId}${hasActive ? ' (active session locked, next session applies)' : ''}`,
+    );
+    return { ok: true, presetId };
+  }
+
+  /**
+   * 清除 per-peer preset 覆盖，回到 config.preset / 默认（新会话生效）
+   */
+  async clearPresetOverride(scope: ChatScope, peerId: string): Promise<PresetSwitchOutcome> {
+    const key = this.sessionKey(scope, peerId);
+    this.modelResolver.clearPreset(key);
+    this.logger.info(`preset pref cleared: key=${key} (next session applies)`);
+    return { ok: true };
+  }
+
+  /**
+   * fork + 重建会话（保留历史，换 model）
+   *
+   * options.route 缺省时沿用当前生效值。preset 沿用当前生效 preset（getEffectivePresetByKey）。
+   * fork 不可用或失败时降级为 dispose（下次消息重建）。
+   */
+  private async rebuildSession(
+    record: SessionRecord,
+    options: { route?: ModelRoute },
+  ): Promise<void> {
+    const key = record.sessionKey;
 
     const sessionsService = this.getSessionsService();
     if (!sessionsService) {
@@ -121,8 +239,8 @@ export class SessionManager {
     }
 
     const childId = SessionId(randomUUID());
-
-    const composed = await this.composePreset(this.config.preset);
+    const effectiveRoute = options.route ?? this.modelResolver.getEffectiveRoute(key);
+    const composed = await this.composePreset(this.getEffectivePresetByKey(key));
     const created = await this.agents.create({
       sessionId: childId,
       seed,
@@ -132,7 +250,7 @@ export class SessionManager {
         seedLength: seed.length,
         ...(composed.agentPreset ? { agentPreset: composed.agentPreset } : {}),
       },
-      agentOptions: route,
+      ...(effectiveRoute ? { agentOptions: effectiveRoute } : {}),
       ...(composed.setup ? { setup: composed.setup } : {}),
     });
 
@@ -146,7 +264,7 @@ export class SessionManager {
     record.lastActivity = Date.now();
 
     void oldHandle.dispose().catch(() => {});
-    this.logger.info(`model switched via fork: key=${key} → ${route.provider}/${route.model} sessionId=${childId}`);
+    this.logger.info(`session rebuilt via fork: key=${key} preset=${composed.agentPreset ?? 'none'} sessionId=${childId}`);
   }
 
   clearModelOverride(scope: ChatScope, peerId: string): void {
@@ -253,13 +371,7 @@ export class SessionManager {
   }
 
   private async composePreset(presetId?: string): Promise<PresetComposition> {
-    let presets: AgentPresetsLike | undefined;
-    try {
-      presets = this.ctx.get('agentPresets') as AgentPresetsLike | undefined;
-    } catch {
-      // agentPresets 服务未注入，降级跳过
-    }
-
+    const presets = this.getPresetsService();
     if (!presets) return {};
 
     try {
@@ -308,8 +420,10 @@ export class SessionManager {
       agent = live;
       this.logger.info(`reusing live agent: key=${key}`);
     } else {
-      // preset 只解析一次：resume/create 共用同一组合，避免重复 resolve/mount 目录
-      const composed = await this.composePreset(this.config.preset);
+      // preset 只解析一次：resume/create 共用同一组合，避免重复 resolve/mount 目录。
+      // 优先 session 当初的 preset（started 锁定语义），无则用当前 effective preset。
+      const presetId = (await this.resolvePersistedPreset(sessionId)) ?? this.getEffectivePresetByKey(key);
+      const composed = await this.composePreset(presetId);
       agentPreset = composed.agentPreset;
       try {
         const resumeRoute = this.modelResolver.getResumeRoute(key);
@@ -394,7 +508,7 @@ export class SessionManager {
 
     let compaction: CompactionServiceLike | undefined;
     try {
-      const presets = this.ctx.get('agentPresets') as AgentPresetsLike | undefined;
+      const presets = this.getPresetsService();
       compaction = (presets?.serviceFor(record.agent, 'compaction') ?? this.ctx.get('compaction')) as CompactionServiceLike | undefined;
     } catch {
       compaction = undefined;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -23,7 +23,7 @@ export interface SessionEventLike {
 export interface DshAgent {
   readonly id: string;
   readonly ctx: Context;
-  /** 当前生命周期状态（对齐 dsh Agent.status，用于判断是否正在生成） */
+  /** 当前生命周期状态（用于判断是否正在生成） */
   readonly status: 'idle' | 'running';
   /** 底层 session（fork 时作为 source，events 用于统计/导出） */
   readonly session: {
@@ -61,6 +61,14 @@ export interface CompactOutcome {
   message?: string;
 }
 
+/** preset 切换结果 */
+export interface PresetSwitchOutcome {
+  ok: boolean;
+  reason?: 'unavailable' | 'unknown-preset' | 'broken' | 'failed';
+  presetId?: string;
+  message?: string;
+}
+
 export interface DshAgentHandle {
   agent: DshAgent;
   dispose(): Promise<void>;
@@ -93,10 +101,19 @@ export interface DshAgentRegistry {
 /** agent-presets 服务接口（可选，部署中可能没有） */
 export interface AgentPresetsLike {
   readonly defaultId: string;
-  resolve(id?: string): Promise<{ id: string }>;
+  resolve(id?: string): Promise<{ id: string; broken?: string }>;
   mount(agentCtx: Context, id?: string): Promise<unknown>;
+  /** 列出所有可用 preset */
+  list(): Promise<Array<{ id: string; name?: string; description?: string; broken?: string }>>;
   /** 从 agent 的 preset scope 解析隔离服务（如 compaction），未挂载返回 undefined */
   serviceFor(agent: { ctx: Context }, name: string): unknown | undefined;
+}
+
+/** 可用 preset 条目（/preset 命令展示用） */
+export interface PresetEntry {
+  id: string;
+  name?: string;
+  description?: string;
 }
 
 /** preset 组合结果 */

--- a/src/transport/attachment.ts
+++ b/src/transport/attachment.ts
@@ -3,7 +3,7 @@
  *
  * 下载后仅通过本地绝对路径提示模型，由模型通过 qqbot_describe_image / ffmpeg / tool-fs 等工具自行分析，
  *
- * 下载目录固定为 ~/.dsh-qqbot/media（对齐 dsh-qqbot 的 prefs 目录约定），
+ * 下载目录固定为 ~/.dsh-qqbot/media，
  * 文件名用时间戳+随机数防重名，不依赖 agent cwd，便于 qqbot_describe_image / tool-fs 等工具稳定访问。
  */
 import { mkdirSync, writeFileSync } from 'node:fs';

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -1,7 +1,7 @@
 /**
  * 入站处理器 — 经 SDK 中间件链处理后的消息 → dsh Agent followup
  *
- * 对齐 openclaw-qqbot body-assembler 的内容组装逻辑：
+ * 内容组装逻辑：
  * - Layer 1: userContent（文本 + 语音转录）
  * - Layer 2: quotePart（引用消息块）
  * - Layer 3: userMessage（带发送者标签）
@@ -130,14 +130,14 @@ export async function handleInbound(
   record.agent.followup(message);
   logger.info(`→ followup sent: key=${scope}:${peerId}`);
 
-  // 群消息回复后清空历史缓存（避免下次 @ 时重复组包，对齐 openclaw-qqbot dispatch）
+  // 群消息回复后清空历史缓存（避免下次 @ 时重复组包）
   if (scope === 'group') {
     clearGroupHistory(config.appId, msg.groupOpenid ?? msg.senderId);
   }
 }
 
 // ══════════════════════════════════════════════════════════════
-// Body Assembly（对齐 openclaw-qqbot 5 层组装）
+// Body Assembly（5 层组装）
 // ══════════════════════════════════════════════════════════════
 
 /**

--- a/src/transport/outbound.ts
+++ b/src/transport/outbound.ts
@@ -182,7 +182,7 @@ class OutboundRouter {
  * 创建出站事件处理器
  *
  * 返回一个 handler 函数，应注册到 ctx.on('session/event', handler)。
- * toolsRegistry 用于工具结果的结构化展示（参考 dsh-TUI 的 presentResult）。
+ * toolsRegistry 用于工具结果的结构化展示。
  */
 export function createOutboundHandler(
   manager: SessionManager,

--- a/src/transport/tool-presenter.ts
+++ b/src/transport/tool-presenter.ts
@@ -1,7 +1,6 @@
 /**
  * 工具调用结果 → Markdown 格式化
  *
- * 参考 dsh-TUI 的 presentResult 机制（channel.ts presentResultView），
  * 适配 QQ 消息通道：优先用工具自定义的 presentResult 视图，
  * fallback 到 raw text。错误始终展示，成功结果按 config 开关。
  */


### PR DESCRIPTION
## Summary

Add a `/preset` command so users can view and switch agent presets per conversation, backed by per-peer preset overrides that persist across sessions.

## Changes

### 1. New `/preset` command

`src/commands/preset.ts` registers a command in the `agent` category:

- **No argument**: lists all available presets plus the current one. Each entry renders as a clickable `<qqbot-cmd-input text="/preset <id>"/>` chip for one-tap switching.
- **`/preset <id>`**: switches the peer to the given preset.
- **`/preset reset`** (alias `default`): clears the per-peer override and returns to the deployment default.
- The switch applies to **new sessions** (`/new`); the current in-flight session keeps its original preset.

### 2. Per-peer preset overrides

- `PrefsStore` is generalized from model-only to "session preferences" (`model` + `preset`) with persistence.
- `ModelResolver` gains `getPreset` / `setPreset` / `clearPreset`.
- `SessionManager` gains:
  - `listPresets()` / `getEffectivePreset()` / `setPresetOverride()` / `clearPresetOverride()`
  - Preset resolution happens **once per session**: `resume` and `create` share the same composition. If a session was started with a preset, it keeps that preset (started-lock semantics); otherwise the current effective preset is used.

### 3. Agent presets service integration

- Registered `@deepseek-ai/dsh-agent-presets` in `cordis.yml` with `default: standard` and a system preset root (`./apps/cli/config/agent-presets`, overridable via the new `DSH_PRESET_ROOT` env var).
- Extended `AgentPresetsLike`:
  - `resolve()` now returns a `broken` flag so load failures are surfaced.
  - Added `list()` to enumerate available presets for the command.
- Added `PresetSwitchOutcome` (`unavailable` / `unknown-preset` / `broken` / `failed`) and `PresetEntry` types.

### 4. Error handling

`/preset` returns friendly messages for each failure mode: service not injected, unknown preset id, broken preset (with detail), or generic failure.

### 5. Docs & cleanup

- Updated `README.md` / `README_EN.md` command tables.
- Removed stale "align with openclaw-qqbot / dsh-TUI" comments across several files (no behavior change).