### PR TITLE
feat(session): inject scope-based system prompt and await turn idle

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -22,7 +22,7 @@
         textChunkLimit: 4500
         sessionIdleTimeout: 1800000
         maxQueue: 20
-        processingTimeoutMs: 120000
+        processingTimeoutMs: 1800000
         historyLimit: 10
         access:
           c2cMode: open

--- a/src/config.ts
+++ b/src/config.ts
@@ -106,7 +106,7 @@ export const ConfigSchema: Schema<ImQQBotConfig> = Schema.object({
   streaming: Schema.boolean().default(true).description('是否启用流式输出（群聊始终不启用）'),
   sessionIdleTimeout: Schema.number().default(30 * 60 * 1000).description('会话闲置超时(ms)'),
   maxQueue: Schema.number().default(20).description('并发队列最大长度'),
-  processingTimeoutMs: Schema.number().default(120000).description('处理超时(ms)'),
+  processingTimeoutMs: Schema.number().default(30 * 60 * 1000).description('处理超时(ms)，超时中断当前 LLM 调用'),
   historyLimit: Schema.number().default(10).description('群历史缓冲条数'),
   access: Schema.object({
     c2cMode: Schema.union(['open', 'allowlist', 'disabled']).default('open').description('C2C访问模式'),

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -49,7 +49,7 @@ export async function bootstrapGateway(
     if (config.debug) {
       logger.debug(`← message (post-middleware): ${JSON.stringify(msg, null, 2).slice(0, 500)}`);
     }
-    await handleInbound(msg, manager, config, logger, mCtx.state);
+    await handleInbound(mCtx, manager, config, logger);
   });
 
   // ── 出站：dsh session/event → QQ 消息 ──

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -46,6 +46,24 @@ const COMPACTION_ERROR_HINTS: Record<string, string> = {
   persistence: '压缩完成但保存失败',
 };
 
+/** system-prompt section 最小结构（name/order/text） */
+interface PromptSection {
+  name: string;
+  order: number;
+  text: string;
+}
+
+/** system-prompt/assemble waterfall 的 context 最小结构 */
+interface AssembleContext {
+  agent?: DshAgent;
+}
+
+/** system-prompt/assemble 的组装产物最小结构 */
+interface AssembledPrompt {
+  sections?: PromptSection[];
+  [key: string]: unknown;
+}
+
 export class SessionManager {
   private sessions = new Map<string, SessionRecord>();
   private readonly evictor: IdleEvictor;
@@ -69,6 +87,41 @@ export class SessionManager {
         void record.handle.dispose().catch(() => {});
       },
     );
+
+    this.registerScopePromptInjection();
+  }
+
+  /**
+   * 通过 system-prompt/assemble waterfall 注入群聊/私聊额外 system prompt。
+   *
+   * 该事件在每次 turn 构建 request 时触发；此处按会话 scope（群聊/私聊）
+   * 追加对应的额外 prompt section。会话尚未建立（首次 assemble）或未配置
+   * 额外 prompt 时原样返回，不做改动。
+   */
+  private registerScopePromptInjection(): void {
+    const assemble = async (
+      _assembly: unknown,
+      context: AssembleContext,
+      next: () => Promise<AssembledPrompt>,
+    ): Promise<AssembledPrompt> => {
+      const assembled = await next();
+      if (!context.agent) return assembled;
+
+      const record = this.findByAgent(context.agent);
+      if (!record) return assembled;
+
+      const prompt = record.scope === 'group' ? this.config.groupPrompt : this.config.directPrompt;
+      if (!prompt) return assembled;
+
+      return {
+        ...assembled,
+        sections: [...(assembled.sections ?? []), { name: 'qqbot:scope-prompt', order: 90, text: prompt }],
+      };
+    };
+
+    (this.ctx as unknown as {
+      on(event: 'system-prompt/assemble', handler: typeof assemble): void;
+    }).on('system-prompt/assemble', assemble);
   }
 
   /**

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -134,6 +134,13 @@ export async function handleInbound(
   if (scope === 'group') {
     clearGroupHistory(config.appId, msg.groupOpenid ?? msg.senderId);
   }
+
+  // 阻塞等待本轮 turn 收敛，避免后续消息在 turn 运行期间被 followup 打断
+  try {
+    await record.agent.whenIdle();
+  } catch (err) {
+    logger.warn(`whenIdle rejected: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 // ══════════════════════════════════════════════════════════════

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -20,6 +20,7 @@ import {
   type MediaKind,
 } from './attachment.js';
 import { clearGroupHistory } from '../features/history-store.js';
+import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
 
 // ── 类型定义 ──
 
@@ -85,14 +86,14 @@ interface ProcessedAttachment {
  * 处理 QQ 入站消息（已经过 SDK 中间件链）
  */
 export async function handleInbound(
-  rawMsg: unknown,
+  ctx: MiddlewareContext,
   manager: SessionManager,
   config: ImQQBotConfig,
   logger: Logger,
-  state?: Record<string, unknown>,
 ): Promise<void> {
-  const msg = rawMsg as ProcessedMessage;
-  const mwState = (state ?? {}) as MiddlewareState;
+  const msg = ctx.message as unknown as ProcessedMessage;
+  const mwState = ctx.state as MiddlewareState;
+  const { bot } = ctx;
 
   const scope: ChatScope = msg.kind === 'group' ? 'group' : 'c2c';
   const peerId = scope === 'group' ? (msg.groupOpenid ?? msg.senderId) : msg.senderId;
@@ -116,6 +117,12 @@ export async function handleInbound(
     record = await manager.getOrCreate(scope, peerId, msg.senderId, replyTarget);
   } catch (err) {
     logger.error(`ERROR creating session: ${err instanceof Error ? err.message : String(err)}`);
+    // 兜底回复：会话创建失败时告知用户，避免静默无响应
+    try {
+      await bot.sendMarkdown(replyTarget, '⚠️ 处理消息时出现异常，请稍后重试。');
+    } catch (sendErr) {
+      logger.error(`fallback reply failed: ${sendErr instanceof Error ? sendErr.message : String(sendErr)}`);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

Improve session robustness and per-scope prompting: inject scope-specific system prompts via the assemble waterfall, wait for the in-flight turn to settle before accepting the next message, add a fallback reply on session-creation failure, and extend the processing timeout to 30 minutes.

## Changes

### 1. Scope-based system prompt injection

`src/session/session-manager.ts` registers a `system-prompt/assemble` waterfall hook:

- Appends an extra prompt section named `qqbot:scope-prompt` (order `90`) on every request assembly.
- The injected text is chosen by session scope: `config.groupPrompt` for group chats, `config.directPrompt` for direct chats.
- No-op when the session isn't established yet (first assemble) or when the scope's prompt isn't configured — the assembled prompt is returned unchanged.
- Minimal structural interfaces (`PromptSection` / `AssembleContext` / `AssembledPrompt`) keep the dependency surface small.

### 2. Wait for turn completion

`src/transport/inbound.ts` now awaits `record.agent.whenIdle()` after enqueuing a message, so a follow-up message isn't interrupted while the current turn is still running. Rejections are logged as warnings, not fatal.

### 3. Inbound refactor & fallback reply

- `handleInbound` now takes the full `MiddlewareContext` instead of `(rawMsg, state)`, giving direct access to `ctx.bot`, `ctx.message`, and `ctx.state`. `bootstrapGateway` passes `mCtx` directly.
- On session-creation failure, a fallback Markdown reply (`⚠️ 处理消息时出现异常，请稍后重试。`) is sent via `bot.sendMarkdown` to avoid silently dropping the message; send failures are logged.

### 4. Processing timeout

- `processingTimeoutMs` default raised from `120000` (2 min) to `30 * 60 * 1000` (30 min), with the description clarified to "超时中断当前 LLM 调用" (timeout aborts the in-flight LLM call).
- `cordis.patch.yml` aligned to the same `1800000`.
