### PR TITLE
feat(question): add ask_user_question QQ channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 | `directPrompt` | string | - | 私聊额外 system prompt |
 | `textChunkLimit` | number | `4500` | 单条消息最大字符数 |
 | `sessionIdleTimeout` | number | `1800000` | 会话闲置超时(ms)，默认 30 分钟 |
+| `askTimeoutMs` | number | `300000` | 待答问题超时(ms)，默认 5 分钟（ask_user_question） |
 | `debug` | boolean | `false` | 调试模式 |
 
 ## 内置命令
@@ -137,6 +138,7 @@ sessionKey: `qqbot:${appId}:${scope}:${peerId}`，由 SHA-256 确定性派生 Se
 - **Preset 支持** — 可通过 `agent-presets` 服务挂载预设（工具集、prompt 等）
 - **闲置回收** — 超时自动 dispose Agent，防止内存泄漏
 - **Markdown 输出** — 回复以 Markdown 格式发送，支持代码块/表格感知切分
+- **问答互动** — 支持 `ask_user_question`，单选生成内联按钮（点一个其余变灰）、多选回复编号，逐题推进 + 问题级超时
 
 ## 本地开发
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -79,6 +79,7 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 | `directPrompt` | string | - | Extra system prompt for direct chats |
 | `textChunkLimit` | number | `4500` | Max chars per message |
 | `sessionIdleTimeout` | number | `1800000` | Session idle timeout (ms), default 30 min |
+| `askTimeoutMs` | number | `300000` | Question timeout (ms), default 5 min (ask_user_question) |
 | `debug` | boolean | `false` | Debug mode |
 
 ## Built-in Commands
@@ -137,6 +138,7 @@ Resolution strategy: in-process reuse → persisted resume → fresh create.
 - **Preset support** — mount presets (toolkits, prompts, etc.) via the `agent-presets` service
 - **Idle eviction** — auto-dispose Agents on timeout to prevent memory leaks
 - **Markdown output** — replies sent as Markdown with code-block/table-aware chunking
+- **Question interaction** — supports `ask_user_question` with inline keyboard buttons (mutually exclusive) or numbered replies, one question at a time with timeout
 
 ## Local Development
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,8 @@ export interface ImQQBotConfig {
   maxQueue: number;
   /** 处理超时(ms)，超时中断当前 LLM 调用 */
   processingTimeoutMs: number;
+  /** 待答问题超时(ms)，超时自动拒绝并提示（ask_user_question） */
+  askTimeoutMs: number;
   /** 群历史缓冲条数 */
   historyLimit: number;
   /** 访问控制 */
@@ -107,6 +109,7 @@ export const ConfigSchema: Schema<ImQQBotConfig> = Schema.object({
   sessionIdleTimeout: Schema.number().default(30 * 60 * 1000).description('会话闲置超时(ms)'),
   maxQueue: Schema.number().default(20).description('并发队列最大长度'),
   processingTimeoutMs: Schema.number().default(30 * 60 * 1000).description('处理超时(ms)，超时中断当前 LLM 调用'),
+  askTimeoutMs: Schema.number().default(5 * 60 * 1000).description('待答问题超时(ms)，超时自动拒绝并提示'),
   historyLimit: Schema.number().default(10).description('群历史缓冲条数'),
   access: Schema.object({
     c2cMode: Schema.union(['open', 'allowlist', 'disabled']).default('open').description('C2C访问模式'),

--- a/src/features/answer-parser.ts
+++ b/src/features/answer-parser.ts
@@ -1,0 +1,28 @@
+/**
+ * QQ 文本回复 → 结构化答案（纯函数，便于单测）。
+ *
+ * 逐题解析：一次解析一个问题的答案。
+ */
+import type { UserQuestion, UserQuestionAnswer } from './question-channel.js';
+
+/** 把用户对单个问题的文本回复解析为答案 */
+export function parseAnswer(question: UserQuestion, text: string): UserQuestionAnswer {
+  const opts = question.options ?? [];
+  if (opts.length > 0) {
+    // 纯数字/分隔符 → 按编号选择
+    if (/^[\d\s,，、;；./]+$/.test(text)) {
+      const nums = [...text.matchAll(/\d+/g)]
+        .map((m) => parseInt(m[0], 10))
+        .filter((n) => n >= 1 && n <= opts.length);
+      if (nums.length > 0) {
+        const picked = question.multiSelect ? nums : nums.slice(0, 1);
+        const selected = [...new Set(picked.map((n) => opts[n - 1]?.label).filter((l): l is string => typeof l === 'string'))];
+        return { id: question.id, selected };
+      }
+    }
+    // 文本与某个选项 label 完全一致（忽略大小写）
+    const exact = opts.find((o) => o.label.toLowerCase() === text.toLowerCase());
+    if (exact) return { id: question.id, selected: [exact.label] };
+  }
+  return { id: question.id, selected: [], custom: text };
+}

--- a/src/features/question-channel.test.ts
+++ b/src/features/question-channel.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { InteractionEvent } from '@tencent-connect/qqbot-nodejs';
+import {
+  QuestionChannel,
+  type UserQuestion,
+  type UserQuestionRequest,
+  type UserQuestionResult,
+  type QuestionSessionRecordLike,
+} from './question-channel.js';
+import { buildKeyboard, formatQuestion } from './question-renderer.js';
+import { parseAnswer } from './answer-parser.js';
+import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+
+function createLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+interface SentMessage {
+  text: string;
+  opts?: { keyboard?: unknown };
+}
+
+function createSender(sent: SentMessage[], opts?: { failKeyboard?: boolean }) {
+  return {
+    sendMarkdown: vi.fn(async (_target: ReplyTarget, content: string, o?: { keyboard?: unknown }) => {
+      if (o?.keyboard && opts?.failKeyboard) throw new Error('keyboard not permitted');
+      sent.push({ text: content, opts: o });
+    }),
+  };
+}
+
+const sessionKey = (scope: ChatScope, peerId: string): string => `qqbot:app:${scope}:${peerId}`;
+
+function makeRecord(sessionKeyStr: string, scope: ChatScope = 'c2c'): QuestionSessionRecordLike {
+  return { sessionKey: sessionKeyStr, scope, replyTarget: { scope, targetId: 'x', msgId: 'm' } };
+}
+
+function createManager(opts?: {
+  findBySessionId?: (id: string) => QuestionSessionRecordLike | undefined;
+  getSessionRecord?: (scope: ChatScope, peerId: string) => QuestionSessionRecordLike | undefined;
+}) {
+  return {
+    findBySessionId: opts?.findBySessionId ?? (() => undefined),
+    // 默认按 scope+peerId 派生 sessionKey 反查，与 startAsk 的 key 生成保持一致
+    getSessionRecord: opts?.getSessionRecord ?? ((scope: ChatScope, peerId: string) => makeRecord(sessionKey(scope, peerId), scope)),
+  };
+}
+
+function startAsk(
+  ch: QuestionChannel,
+  scope: ChatScope,
+  peerId: string,
+  questions: UserQuestion[],
+  signal?: AbortSignal,
+): Promise<UserQuestionResult> {
+  const key = sessionKey(scope, peerId);
+  const request: UserQuestionRequest = { questions, ...(signal ? { signal } : {}) };
+  return ch.askViaQQ(makeRecord(key, scope), request);
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+const q2 = (id = 'q'): UserQuestion => ({ id, question: '选哪个？', options: [{ label: 'A' }, { label: 'B' }] });
+
+describe('formatQuestion', () => {
+  it('renders numbered options with description and text hint', () => {
+    const q: UserQuestion = {
+      id: 'q',
+      question: '选哪个？',
+      options: [{ label: 'A', description: '描述A' }, { label: 'B' }],
+    };
+    const text = formatQuestion(q, false, false);
+    expect(text).toContain('1. A · 描述A');
+    expect(text).toContain('2. B');
+    expect(text).toContain('> 💡 回复编号选择');
+    expect(text).toContain('直接输入你的想法');
+  });
+
+  it('uses button hint with emoji when withButtons', () => {
+    expect(formatQuestion(q2(), false, true)).toContain('> 👇 点击下方按钮选择');
+  });
+
+  it('prefixes multi-select marker and multi-pick hint', () => {
+    const q: UserQuestion = { id: 'q', question: '选哪些？', options: [{ label: 'A' }, { label: 'B' }], multiSelect: true };
+    const text = formatQuestion(q, false, false);
+    expect(text).toContain('选哪些？（可多选）');
+    expect(text).toContain('> 💡 回复多个编号即可多选（如 1,3）');
+  });
+
+  it('adds @mention note for groups', () => {
+    expect(formatQuestion(q2(), true, false)).toContain('需 @机器人');
+  });
+});
+
+describe('buildKeyboard', () => {
+  it('lays out two options in a single row of two buttons', () => {
+    const kb = buildKeyboard(q2());
+    expect(kb?.content.rows).toHaveLength(1);
+    expect(kb?.content.rows[0]?.buttons).toHaveLength(2);
+    const btn = kb?.content.rows[0]?.buttons[0];
+    expect(btn?.action.type).toBe(1);
+    expect(btn?.action.permission.type).toBe(2);
+    // 单选互斥：同一题选项共享 group_id，点一个后其余变灰（action.type=1 才生效）
+    expect(btn?.group_id).toBe('q-q');
+    // 保留 click_limit=1（每人限点一次，与 openclaw 对齐）
+    expect(btn?.action.click_limit).toBe(1);
+    expect(btn?.render_data.label).toBe('A');
+    expect(btn?.render_data.visited_label).toBe('✓ 已选');
+    // button_data 同时编码 question.id 与选项下标，供 handleInteraction 校验归属题
+    expect(btn?.id).toBe('q-q-opt-0');
+    expect(JSON.parse(btn!.action.data)).toEqual({ q: 'q', i: 0 });
+  });
+
+  it('wraps options across multiple rows', () => {
+    const opts = [{ label: 'A' }, { label: 'B' }, { label: 'C' }, { label: 'D' }, { label: 'E' }];
+    const kb = buildKeyboard({ id: 'q', question: 't', options: opts });
+    expect(kb?.content.rows).toHaveLength(3); // 2+2+1
+    expect(kb?.content.rows[0]?.buttons).toHaveLength(2);
+    expect(kb?.content.rows[2]?.buttons).toHaveLength(1);
+    expect(JSON.parse(kb!.content.rows[2]!.buttons[0]!.action.data)).toEqual({ q: 'q', i: 4 });
+  });
+
+  it('returns undefined for multi-select or no-options', () => {
+    expect(buildKeyboard({ ...q2(), multiSelect: true })).toBeUndefined();
+    expect(buildKeyboard({ id: 'q', question: 't' })).toBeUndefined();
+  });
+});
+
+describe('parseAnswer', () => {
+  it('maps numbers to option labels', () => {
+    expect(parseAnswer(q2(), '2')).toEqual({ id: 'q', selected: ['B'] });
+  });
+
+  it('supports multi-select numbers', () => {
+    const q: UserQuestion = { id: 'q', question: 't', options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }], multiSelect: true };
+    expect(parseAnswer(q, '1,3')).toEqual({ id: 'q', selected: ['A', 'C'] });
+  });
+
+  it('falls back to custom for free text and out-of-range', () => {
+    expect(parseAnswer(q2(), '9')).toEqual({ id: 'q', selected: [], custom: '9' });
+    expect(parseAnswer(q2(), '自定义')).toEqual({ id: 'q', selected: [], custom: '自定义' });
+  });
+
+  it('no options → custom', () => {
+    expect(parseAnswer({ id: 'q', question: 't' }, '小明')).toEqual({ id: 'q', selected: [], custom: '小明' });
+  });
+});
+
+describe('QuestionChannel.tryAnswer', () => {
+  it('resolves single-question and consumes the message', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    expect(ch.tryAnswer('c2c', 'U1', '2')).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['B'] }] });
+  });
+
+  it('advances multi-question one by one', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const q1: UserQuestion = { id: 'a', question: '问题1', options: [{ label: 'A1' }, { label: 'B1' }] };
+    const q2b: UserQuestion = { id: 'b', question: '问题2', options: [{ label: 'A2' }, { label: 'B2' }] };
+    const p = startAsk(ch, 'c2c', 'U1', [q1, q2b]);
+    await sleep(20);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.text).toContain('问题1');
+
+    expect(ch.tryAnswer('c2c', 'U1', '1')).toBe(true);
+    await sleep(20);
+    expect(sent).toHaveLength(2);
+    expect(sent[1]!.text).toContain('问题2');
+
+    expect(ch.tryAnswer('c2c', 'U1', '2')).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'a', selected: ['A1'] }, { id: 'b', selected: ['B2'] }] });
+  });
+
+  it('ignores empty text and returns false when no pending question', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    expect(ch.tryAnswer('c2c', 'nobody', '1')).toBe(false);
+
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    expect(ch.tryAnswer('c2c', 'U1', '')).toBe(false);
+    ch.tryAnswer('c2c', 'U1', '1');
+    await p;
+  });
+});
+
+describe('QuestionChannel.askViaQQ', () => {
+  it('attaches keyboard for single-select', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: true, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    expect(sent[0]?.opts?.keyboard).toBeDefined();
+    expect(sent[0]?.text).toContain('点击下方按钮选择');
+    ch.tryAnswer('c2c', 'U1', '1');
+    await p;
+  });
+
+  it('falls back to plain text when keyboard send fails', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent, { failKeyboard: true }), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.opts).toBeUndefined();
+    expect(sent[0]?.text).toContain('回复编号选择');
+    ch.tryAnswer('c2c', 'U1', '1');
+    await p;
+  });
+
+  it('rejects when the question cannot be delivered at all', async () => {
+    const ch = new QuestionChannel(
+      createManager(),
+      { sendMarkdown: vi.fn(async () => { throw new Error('network down'); }) },
+      { requireMention: false, askTimeoutMs: 60_000 },
+      createLogger(),
+    );
+    await expect(ch.askViaQQ(makeRecord('sx'), { questions: [q2()] }))
+      .rejects.toThrow('failed to deliver question to QQ');
+  });
+
+  it('rejects on abort signal', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const ac = new AbortController();
+    const p = startAsk(ch, 'c2c', 'U1', [q2()], ac.signal);
+    await sleep(20);
+    ac.abort();
+    await expect(p).rejects.toThrow('aborted');
+  });
+
+  it('supersedes a previous pending question for the same session', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p1 = startAsk(ch, 'c2c', 'U1', [q2()]);
+    p1.catch(() => {});
+    await sleep(20);
+    const p2 = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    await expect(p1).rejects.toThrow('superseded');
+    ch.tryAnswer('c2c', 'U1', '1');
+    await p2;
+  });
+
+  it('times out and rejects when the user never answers', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 20 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    p.catch(() => {}); // 抑制超时 reject 早于断言挂 handler 的 unhandled rejection
+    await sleep(80);
+    await expect(p).rejects.toThrow('timed out');
+    expect(sent.some((s) => s.text.includes('超时'))).toBe(true);
+  });
+});
+
+describe('QuestionChannel.handleInteraction', () => {
+  function makeEvent(data: string | undefined, peer: { user?: string; group?: string }): InteractionEvent {
+    return {
+      id: 'i1',
+      type: 1,
+      version: 1,
+      ...(peer.group ? { group_openid: peer.group } : {}),
+      ...(peer.user ? { user_openid: peer.user } : {}),
+      data: { type: 1, resolved: { ...(data !== undefined ? { button_data: data } : {}) } },
+    } as InteractionEvent;
+  }
+
+  it('answers a c2c question by button click', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 1 }), { user: 'U1' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['B'] }] });
+  });
+
+  it('routes group clicks by group_openid', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'group', 'G1', [q2()]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 0 }), { user: 'someone', group: 'G1' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['A'] }] });
+  });
+
+  it('resolves with the full original label for truncated buttons', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const long = '这是一个非常非常长的选项标签超过十八个字符的限制了吧';
+    const p = startAsk(ch, 'c2c', 'U7', [{ id: 'q', question: 't', options: [{ label: long }] }]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 0 }), { user: 'U7' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: [long] }] });
+  });
+
+  it('rejects malformed or stale clicks without consuming the question', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U2', [q2()]);
+    await sleep(20);
+    expect(ch.handleInteraction(makeEvent('not-json', { user: 'U2' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 9 }), { user: 'U2' }))).toBe(false);
+    // 旧题按钮：q 不等于当前题 id，忽略
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'other', i: 0 }), { user: 'U2' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 0 }), { user: 'nobody' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(undefined, { user: 'U2' }))).toBe(false);
+    ch.tryAnswer('c2c', 'U2', '1');
+    await p;
+  });
+
+  it('ignores a stale click from a previous question after advancing', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const q1: UserQuestion = { id: 'a', question: '问题1', options: [{ label: 'A1' }, { label: 'B1' }] };
+    const q2b: UserQuestion = { id: 'b', question: '问题2', options: [{ label: 'A2' }, { label: 'B2' }] };
+    const p = startAsk(ch, 'c2c', 'U1', [q1, q2b]);
+    await sleep(20);
+    // 答第一题（按钮点击），推进到第二题
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'a', i: 0 }), { user: 'U1' }))).toBe(true);
+    await sleep(20);
+    expect(sent).toHaveLength(2); // 第二题已发出
+    // 旧题（q=a）按钮在新题发出后被点击 → 忽略，不消费当前题
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'a', i: 1 }), { user: 'U1' }))).toBe(false);
+    // 当前题（q=b）仍可正常作答
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'b', i: 1 }), { user: 'U1' }))).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'a', selected: ['A1'] }, { id: 'b', selected: ['B2'] }] });
+  });
+});
+
+describe('QuestionChannel.cancelPending', () => {
+  it('rejects pending question when the session is evicted', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const p = startAsk(ch, 'c2c', 'U1', [q2()]);
+    await sleep(20);
+    ch.cancelPending(sessionKey('c2c', 'U1'));
+    await expect(p).rejects.toThrow('cancelled');
+  });
+});
+
+describe('QuestionChannel.install routing', () => {
+  it('routes QQ sessions to QQ channel and delegates others', async () => {
+    const sent: SentMessage[] = [];
+    const record = makeRecord(sessionKey('c2c', 'u9'));
+    (record as { sessionId?: string }).sessionId = 'sess-qq';
+    const manager = createManager({ findBySessionId: (id) => (id === 'sess-qq' ? record : undefined) });
+    const ch = new QuestionChannel(manager, createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    let origCalled = 0;
+    const uq = { ask: vi.fn(async () => { origCalled += 1; return { answers: [] }; }) };
+    ch.install({ get: (n: string) => (n === 'userQuestions' ? uq : undefined) });
+
+    await uq.ask({ questions: [q2('x')], agent: { id: 'sess-web' } });
+    expect(origCalled).toBe(1);
+
+    const p = uq.ask({ questions: [q2()], agent: { id: 'sess-qq' } });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ch.tryAnswer('c2c', 'u9', '1')).toBe(true);
+    expect(await p).toEqual({ answers: [{ id: 'q', selected: ['A'] }] });
+    expect(origCalled).toBe(1); // QQ 路径未触碰原实现
+  });
+
+  it('uninstall restores the original ask', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
+    const uq: { ask: (r: UserQuestionRequest) => Promise<UserQuestionResult>; __qqQuestionPatched?: boolean } = {
+      ask: async () => ({ answers: [] }),
+    };
+    ch.install({ get: (n: string) => (n === 'userQuestions' ? uq : undefined) });
+    expect(uq.__qqQuestionPatched).toBe(true);
+    ch.uninstall();
+    expect(uq.__qqQuestionPatched).toBeUndefined();
+  });
+
+  it('disables gracefully when the userQuestions service is missing', () => {
+    const sent: SentMessage[] = [];
+    const logger = createLogger();
+    const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, logger);
+    ch.install({ get: () => undefined });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/question-channel.ts
+++ b/src/features/question-channel.ts
@@ -1,0 +1,324 @@
+/**
+ * QuestionChannel — 把 dsh 的 ask_user_question 桥接到 QQ 通道。
+ *
+ * 接入方式：包装 `userQuestions.ask`（而非 registerProvider），按 `request.agent.id`
+ * 路由到 QQ 会话；非 QQ 会话委托宿主默认 provider（如 Web 弹出框），多通道共存。
+ *
+ * 每会话一个显式状态机，三态语义：
+ *   - 待答（pending 中）：等待当前题的回答
+ *   - 逐题推进：多问题时一次问一题，答完一题再问下一题
+ *   - 完成 / 中断（abort / 超时 / 会话回收）：reject(ASK_ABORTED)
+ */
+import type { InlineKeyboard, InteractionEvent } from '@tencent-connect/qqbot-nodejs';
+import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+import { parseAnswer } from './answer-parser.js';
+import { buildKeyboard, formatQuestion } from './question-renderer.js';
+
+// ── 最小契约（对齐 dsh-user-questions，避免硬依赖） ──
+
+export interface UserQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface UserQuestion {
+  id: string;
+  header?: string;
+  question: string;
+  options?: UserQuestionOption[];
+  multiSelect?: boolean;
+}
+
+export interface UserQuestionAnswer {
+  id: string;
+  selected: string[];
+  custom?: string;
+}
+
+export interface UserQuestionRequest {
+  questions: UserQuestion[];
+  agent?: { id?: string };
+  signal?: AbortSignal;
+}
+
+export interface UserQuestionResult {
+  answers: UserQuestionAnswer[];
+}
+
+export interface UserQuestionsServiceLike {
+  ask: (request: UserQuestionRequest) => Promise<UserQuestionResult>;
+  __qqQuestionPatched?: boolean;
+}
+
+// ── 依赖接口（结构化，便于单测） ──
+
+export interface QuestionSessionRecordLike {
+  sessionKey: string;
+  scope: ChatScope;
+  replyTarget: ReplyTarget;
+}
+
+export interface QuestionChannelManagerLike {
+  findBySessionId(sessionId: string): QuestionSessionRecordLike | undefined;
+  getSessionRecord(scope: ChatScope, peerId: string): QuestionSessionRecordLike | undefined;
+}
+
+export interface QuestionChannelSenderLike {
+  sendMarkdown(target: ReplyTarget, content: string, opts?: { keyboard?: InlineKeyboard }): Promise<unknown>;
+}
+
+export interface QuestionChannelConfigLike {
+  requireMention: boolean;
+  askTimeoutMs: number;
+}
+
+// ── 错误语义（对齐 dsh-user-questions 的 UserQuestionError code 约定） ──
+
+/** 问答中断错误码：上层（如 plan-mode）按 code 区分「用户未作答」与普通发送/网络错误 */
+const ASK_ABORTED = 'ASK_ABORTED';
+
+class QuestionChannelError extends Error {
+  public constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = 'QuestionChannelError';
+  }
+}
+
+// ── 每会话状态机 ──
+
+interface PendingEntry {
+  record: QuestionSessionRecordLike;
+  request: UserQuestionRequest;
+  resolve: (result: UserQuestionResult) => void;
+  reject: (err: Error) => void;
+  onAbort?: () => void;
+  timer?: ReturnType<typeof setTimeout>;
+  /** 当前正在问的问题在 request.questions 的下标 */
+  index: number;
+  /** 已收集的答案 */
+  collected: UserQuestionAnswer[];
+}
+
+export class QuestionChannel {
+  private readonly pending = new Map<string, PendingEntry>();
+  private uq?: UserQuestionsServiceLike;
+  private origAsk?: UserQuestionsServiceLike['ask'];
+
+  public constructor(
+    private readonly manager: QuestionChannelManagerLike,
+    private readonly sender: QuestionChannelSenderLike,
+    private readonly config: QuestionChannelConfigLike,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * 包装 userQuestions.ask：QQ 会话走 QQ 通道，其余委托原实现。
+   * 幂等（已 patch 则跳过）；服务缺失或 ask 非函数时优雅禁用。
+   */
+  public install(ctx: { get(name: string): unknown }): void {
+    const uq = ctx.get('userQuestions') as UserQuestionsServiceLike | undefined;
+    if (!uq || uq.__qqQuestionPatched) return;
+    if (typeof uq.ask !== 'function') {
+      this.logger.warn('im-qqbot: userQuestions service lacks ask() — QQ question channel disabled');
+      return;
+    }
+
+    const self = this;
+    this.origAsk = uq.ask.bind(uq);
+    uq.ask = async function qqRoutedAsk(request: UserQuestionRequest): Promise<UserQuestionResult> {
+      const sessionId = request?.agent?.id;
+      const record = sessionId ? self.manager.findBySessionId(sessionId) : undefined;
+      if (record) return self.askViaQQ(record, request);
+      return self.origAsk!(request);
+    };
+    Object.defineProperty(uq, '__qqQuestionPatched', { value: true, configurable: true, enumerable: false });
+    this.uq = uq;
+    this.logger.info('im-qqbot: QQ question channel installed');
+  }
+
+  public uninstall(): void {
+    if (this.uq && this.origAsk) {
+      this.uq.ask = this.origAsk;
+      delete this.uq.__qqQuestionPatched;
+      this.uq = undefined;
+      this.origAsk = undefined;
+    }
+    for (const [, entry] of this.pending) {
+      this.clearTimer(entry);
+      this.removeAbort(entry);
+      entry.reject(new QuestionChannelError('QQ question channel was unloaded before the user answered', ASK_ABORTED));
+    }
+    this.pending.clear();
+  }
+
+  /** 会话回收时清理其待答问题，避免 pending 悬挂导致 Promise 与闭包泄漏 */
+  public cancelPending(sessionKey: string): void {
+    const entry = this.pending.get(sessionKey);
+    if (!entry) return;
+    this.pending.delete(sessionKey);
+    this.clearTimer(entry);
+    this.removeAbort(entry);
+    entry.reject(new QuestionChannelError('ask_user_question was cancelled before the user answered', ASK_ABORTED));
+  }
+
+  /** 入站文本作答：该会话若有待答问题且本条消息有文本，解析为答案并推进 */
+  public tryAnswer(scope: ChatScope, peerId: string, text: string): boolean {
+    const record = this.manager.getSessionRecord(scope, peerId);
+    if (!record) return false;
+    const key = record.sessionKey;
+    const entry = this.pending.get(key);
+    if (!entry) return false;
+    if (!text) return false; // 纯图片/表情等：继续等待，消息走常规流程
+
+    const current = entry.request.questions[entry.index];
+    if (!current) return false;
+    const answer = parseAnswer(current, text);
+    this.advance(entry, key, answer);
+    return true;
+  }
+
+  /** 按钮点击作答：解码 button_data 选项下标，推进状态机 */
+  public handleInteraction(event: InteractionEvent): boolean {
+    const peerId = event.group_openid ?? event.user_openid;
+    if (!peerId) return false;
+    const scope: ChatScope = event.group_openid ? 'group' : 'c2c';
+    const record = this.manager.getSessionRecord(scope, peerId);
+    if (!record) return false;
+    const entry = this.pending.get(record.sessionKey);
+    if (!entry) return false;
+
+    const data = event.data?.resolved?.button_data;
+    if (!data) return false;
+    let parsed: { q?: unknown; i?: unknown };
+    try {
+      parsed = JSON.parse(data) as { q?: unknown; i?: unknown };
+    } catch {
+      return false;
+    }
+    const current = entry.request.questions[entry.index];
+    if (!current) return false;
+    // 校验按钮归属题：旧题按钮在新题推进后被点击（误点/延迟事件），
+    // 其 q 不等于当前题 id，直接忽略，避免错位映射到当前题选项。
+    if (parsed.q !== current.id) return false;
+    const i = parsed.i;
+    const opts = current.options ?? [];
+    if (!Number.isInteger(i) || (i as number) < 0 || (i as number) >= opts.length) return false;
+
+    const idx = i as number;
+    this.advance(entry, record.sessionKey, { id: current.id, selected: [opts[idx]!.label] });
+    return true;
+  }
+
+  /** 走 QQ 通道：发送首题 + 挂起 Promise，等待逐题作答 */
+  private async askViaQQ(record: QuestionSessionRecordLike, request: UserQuestionRequest): Promise<UserQuestionResult> {
+    const key = record.sessionKey;
+    // 会话回收/取消可能在发送前发生：signal 已 abort 则直接失败，避免悬挂
+    if (request.signal?.aborted) {
+      throw new QuestionChannelError('ask_user_question was aborted before delivery', ASK_ABORTED);
+    }
+    // 同会话已有待答问题（理论上不会发生：回合阻塞在第一个问题上）→ 拒绝旧的
+    const prev = this.pending.get(key);
+    if (prev) {
+      this.pending.delete(key);
+      this.clearTimer(prev);
+      this.removeAbort(prev);
+      prev.reject(new QuestionChannelError('superseded by a new question', ASK_ABORTED));
+    }
+
+    const first = request.questions[0];
+    if (!first) throw new Error('ask_user_question with empty questions');
+
+    await this.sendQuestion(record, first);
+
+    return new Promise<UserQuestionResult>((resolve, reject) => {
+      const entry: PendingEntry = { record, request, resolve, reject, index: 0, collected: [] };
+      if (request.signal) {
+        const onAbort = (): void => {
+          if (this.pending.get(key) !== entry) return;
+          this.pending.delete(key);
+          this.clearTimer(entry);
+          reject(new QuestionChannelError('ask_user_question was aborted before the user answered', ASK_ABORTED));
+        };
+        entry.onAbort = onAbort;
+        request.signal.addEventListener('abort', onAbort, { once: true });
+      }
+      entry.timer = setTimeout(() => this.onTimeout(key), this.config.askTimeoutMs);
+      this.pending.set(key, entry);
+      this.logger.info(`im-qqbot: question sent to QQ, waiting for answer key=${key}`);
+    });
+  }
+
+  /** 推进状态机：收集答案 → 有下一题则发送，否则 resolve 全部答案 */
+  private advance(entry: PendingEntry, key: string, answer: UserQuestionAnswer): void {
+    entry.collected.push(answer);
+    entry.index += 1;
+
+    if (entry.index < entry.request.questions.length) {
+      const next = entry.request.questions[entry.index]!;
+      this.resetTimer(entry, key);
+      void this.sendQuestion(entry.record, next).catch((err) => {
+        this.pending.delete(key);
+        this.clearTimer(entry);
+        this.removeAbort(entry);
+        entry.reject(err instanceof Error ? err : new Error(String(err)));
+      });
+      return;
+    }
+
+    this.pending.delete(key);
+    this.clearTimer(entry);
+    this.removeAbort(entry);
+    this.logger.info(`im-qqbot: question answered via QQ key=${key}`);
+    entry.resolve({ answers: entry.collected });
+  }
+
+  /** 发送单个问题：优先带按钮，按钮发送失败降级纯文本 */
+  private async sendQuestion(record: QuestionSessionRecordLike, question: UserQuestion): Promise<void> {
+    const hint = record.scope === 'group' && this.config.requireMention === true;
+    const keyboard = buildKeyboard(question);
+    try {
+      if (keyboard) {
+        try {
+          await this.sender.sendMarkdown(record.replyTarget, formatQuestion(question, hint, true), { keyboard });
+          return;
+        } catch (err) {
+          this.logger.warn(`im-qqbot: keyboard send failed, fallback to text: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+      await this.sender.sendMarkdown(record.replyTarget, formatQuestion(question, hint, false));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`im-qqbot: question send failed key=${record.sessionKey}: ${msg}`);
+      throw new Error(`failed to deliver question to QQ: ${msg}`);
+    }
+  }
+
+  private onTimeout(key: string): void {
+    const entry = this.pending.get(key);
+    if (!entry) return;
+    this.pending.delete(key);
+    this.removeAbort(entry);
+    entry.timer = undefined;
+    void this.sender.sendMarkdown(entry.record.replyTarget, '⚠️ 提问已超时，未收到回答。').catch(() => {});
+    entry.reject(new QuestionChannelError('ask_user_question timed out before the user answered', ASK_ABORTED));
+  }
+
+  private resetTimer(entry: PendingEntry, key: string): void {
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = setTimeout(() => this.onTimeout(key), this.config.askTimeoutMs);
+  }
+
+  private clearTimer(entry: PendingEntry): void {
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = undefined;
+  }
+
+  private removeAbort(entry: PendingEntry): void {
+    if (entry.onAbort && entry.request.signal) {
+      entry.request.signal.removeEventListener('abort', entry.onAbort);
+    }
+  }
+}

--- a/src/features/question-renderer.ts
+++ b/src/features/question-renderer.ts
@@ -1,0 +1,94 @@
+/**
+ * QQ 问答的文本渲染与按钮键盘构建（纯函数，便于单测）。
+ *
+ * 逐题渲染：一次只渲染一个问题（多题时由状态机逐题推进）。
+ */
+import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
+import type { UserQuestion } from './question-channel.js';
+
+/** QQ 按钮 label 有长度限制，超长截断（正文保留完整文本；多列布局下阈值更短） */
+const BUTTON_LABEL_MAX = 10;
+
+/** 单选按钮每行个数（多列布局，减少选项多时的刷屏） */
+const BUTTONS_PER_ROW = 2;
+
+function buttonLabel(text: string | undefined): string {
+  const s = String(text ?? '').trim();
+  return s.length > BUTTON_LABEL_MAX ? s.slice(0, BUTTON_LABEL_MAX - 1) + '…' : s;
+}
+
+/**
+ * 为「单选、带选项」的问题构建内联键盘；不适用时返回 undefined。
+ *
+ * 多行多列布局：每行 BUTTONS_PER_ROW 个按钮，减少选项多时的刷屏。
+ *
+ * button_data 编码 `{"q":<问题id>, "i":<选项下标>}`，由 handleInteraction 解码。
+ * 编码 question.id 用于把按钮与「当前正在问的题」关联：逐题推进时，旧题按钮
+ * 在新题发出后被点击（误点/延迟事件），其 q 不等于当前题 id，可被识别并忽略。
+ */
+export function buildKeyboard(question: UserQuestion): InlineKeyboard | undefined {
+  const opts = question.options ?? [];
+  if (opts.length === 0 || question.multiSelect) return undefined;
+
+  const rows: InlineKeyboard['content']['rows'] = [];
+  for (let i = 0; i < opts.length; i += BUTTONS_PER_ROW) {
+    rows.push({
+      buttons: opts.slice(i, i + BUTTONS_PER_ROW).map((o, offset) => {
+        const idx = i + offset;
+        return {
+          id: `q-${question.id}-opt-${idx}`,
+          render_data: {
+            label: buttonLabel(o.label),
+            visited_label: '✓ 已选',
+            style: 1,
+          },
+          action: {
+            type: 1,
+            permission: { type: 2 },
+            click_limit: 1,
+            data: JSON.stringify({ q: question.id, i: idx }),
+          },
+          // 同一题的选项共享分组：点一个后其余变灰（单选互斥）
+          group_id: `q-${question.id}`,
+        };
+      }),
+    });
+  }
+  return { content: { rows } };
+}
+
+/** 把单个问题渲染成 QQ 文本 */
+export function formatQuestion(
+  question: UserQuestion,
+  requireMentionHint: boolean,
+  withButtons: boolean,
+): string {
+  const lines: string[] = [];
+  if (question.header) lines.push(`**${question.header}**`);
+
+  const opts = question.options ?? [];
+  const multi = question.multiSelect === true;
+
+  // 问题行：多选标记前置，用户第一眼就知道作答方式
+  lines.push(multi ? `${question.question}（可多选）` : question.question);
+
+  // 选项列表：保留完整 label + description（按钮 label 截断时 description 靠正文展示）
+  opts.forEach((o, i) => {
+    lines.push(`${i + 1}. ${o.label}${o.description ? ` · ${o.description}` : ''}`);
+  });
+
+  // 底部引导：用引用块（>）与正文区分；mention 放在「回复」动作后（点按钮无需 @）
+  if (opts.length > 0) {
+    lines.push('');
+    const mention = requireMentionHint ? '（需 @机器人）' : '';
+    if (withButtons) {
+      lines.push(`> 👇 点击下方按钮选择，或回复编号${mention}`);
+    } else if (multi) {
+      lines.push(`> 💡 回复多个编号即可多选（如 1,3）${mention}，或直接输入你的想法`);
+    } else {
+      lines.push(`> 💡 回复编号选择${mention}，或直接输入你的想法`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -6,11 +6,12 @@
  */
 import type { Context } from '@deepseek-ai/cordis';
 import { QQBot } from '@tencent-connect/qqbot-nodejs';
-import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
+import type { InteractionEvent, MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
 import { SessionManager, type DshAgentRegistry } from '../session/index.js';
 import { handleInbound, createOutboundHandler } from '../transport/index.js';
 import type { ToolsRegistryLike } from '../transport/tool-presenter.js';
 import type { QQBotSender } from '../transport/outbound-buffer.js';
+import { QuestionChannel } from '../features/question-channel.js';
 import { buildUserAgent } from '../shared/index.js';
 import type { ImQQBotConfig } from '../config.js';
 import type { Logger } from '../types.js';
@@ -63,7 +64,7 @@ export async function bootstrapGateway(
 
   // 发送适配器：将 QQBot 实例适配为 QQBotSender（openStream 参数形态不同）
   const sender: QQBotSender = {
-    sendMarkdown: (target, content) => bot.sendMarkdown(target, content),
+    sendMarkdown: (target, content, opts) => bot.sendMarkdown(target, content, opts),
     openStream: (target) => bot.openStream({
       target: {
         scope: target.scope,
@@ -76,6 +77,17 @@ export async function bootstrapGateway(
   const outboundHandler = createOutboundHandler(manager, sender, config, logger, toolsRegistry);
   (ctx as unknown as { on(event: string, handler: (...args: unknown[]) => void): void })
     .on('session/event', outboundHandler as (...args: unknown[]) => void);
+
+  // ── 问答通道（ask_user_question → QQ 文本 + 按钮） ──
+  const questionChannel = new QuestionChannel(manager, sender, config, logger);
+  manager.questionChannel = questionChannel;
+  questionChannel.install(ctx);
+
+  // ── 按钮点击回调（interaction） ──
+  bot.on('interaction', async (_iCtx: unknown, event: InteractionEvent) => {
+    const matched = questionChannel.handleInteraction(event);
+    await bot.acknowledgeInteraction(event.id, matched ? 0 : 3).catch(() => {});
+  });
 
   bot.on('error', (err: unknown) => {
     logger.error(`bot error: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/gateway/middleware-setup.ts
+++ b/src/gateway/middleware-setup.ts
@@ -24,6 +24,7 @@ import type { SessionManager } from '../session/index.js';
 import type { Logger } from '../types.js';
 import { buildCommandList } from '../commands/index.js';
 import { attachmentProcessor } from '../middleware/attachment.js';
+import { questionAnswer } from '../middleware/question-answer.js';
 import { getHistoryStore, historyGroupKey } from '../features/history-store.js';
 
 export function setupMiddlewares(
@@ -89,6 +90,9 @@ export function setupMiddlewares(
     commands: buildCommandList({ manager, config }),
   });
   bot.use(slash.middleware);
+
+  // 8.5. 待答问题截获（在 concurrencyGuard 之前，答案消息不排队直接作答）
+  bot.use(questionAnswer(manager));
 
   // 9. 并发串行 + 消息合并（同 peer 排队，避免 session 冲突）
   bot.use(concurrencyGuard({

--- a/src/middleware/question-answer.ts
+++ b/src/middleware/question-answer.ts
@@ -1,0 +1,23 @@
+/**
+ * 待答问题截获中间件 — 在中间件链中截获 ask_user_question 的答案
+ *
+ * 必须放在 concurrencyGuard 之前：答案消息需绕过并发守卫的 merge 缓冲，
+ * 否则会被排队而无法到达 tryAnswer，导致「turn 等答案 ↔ 答案被缓冲」死锁。
+ */
+import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
+import type { SessionManager } from '../session/index.js';
+
+export function questionAnswer(manager: SessionManager) {
+  return async (ctx: MiddlewareContext, next: () => Promise<void>): Promise<void> => {
+    const questionChannel = manager.questionChannel;
+    if (!questionChannel) {
+      await next();
+      return;
+    }
+    if (questionChannel.tryAnswer(ctx.replyTarget.scope, ctx.replyTarget.targetId, ctx.message.content.trim())) {
+      ctx.stop('question-answer');
+      return;
+    }
+    await next();
+  };
+}

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -20,6 +20,7 @@ import type { ImQQBotConfig } from '../config.js';
 import { ModelResolver } from '../model/model-resolver.js';
 import type { ModelRoute, ModelEntry } from '../model/types.js';
 import { IdleEvictor } from './idle-evictor.js';
+import type { QuestionChannel } from '../features/question-channel.js';
 import type {
   SessionEventLike,
   DshAgent,
@@ -68,6 +69,8 @@ export class SessionManager {
   private sessions = new Map<string, SessionRecord>();
   private readonly evictor: IdleEvictor;
   private readonly modelResolver: ModelResolver;
+  /** 由 bootstrap 注入的问答通道（ask_user_question → QQ），会话回收时清理其待答问题 */
+  public questionChannel?: QuestionChannel;
 
   constructor(
     private readonly ctx: Context,
@@ -85,6 +88,8 @@ export class SessionManager {
         this.sessions.delete(key);
         record.agent.cancel({ kind: 'user' });
         void record.handle.dispose().catch(() => {});
+        // 回收会话时同步清理其待答问题，避免 pending 悬挂泄漏
+        this.questionChannel?.cancelPending(key);
       },
     );
 

--- a/src/transport/outbound-buffer.ts
+++ b/src/transport/outbound-buffer.ts
@@ -4,6 +4,7 @@
  * 收集流式 chunk，流式优先投递（StreamingWriter），降级为静态发送。
  * 独立文件便于单测。
  */
+import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
 import type { SessionRecord } from '../session/index.js';
 import type { Logger, ReplyTarget } from '../types.js';
 import { chunkMarkdownText } from './chunker.js';
@@ -20,7 +21,7 @@ export interface StreamSessionLike {
 
 /** QQ Bot 发送接口 */
 export interface QQBotSender {
-  sendMarkdown(target: ReplyTarget, content: string): Promise<unknown>;
+  sendMarkdown(target: ReplyTarget, content: string, opts?: { keyboard?: InlineKeyboard }): Promise<unknown>;
   openStream(target: ReplyTarget): StreamSessionLike;
 }
 


### PR DESCRIPTION
## Summary

Bridge dsh's `ask_user_question` into the QQ channel, so the agent can ask the user questions directly in chat: single-select questions render as inline keyboard buttons (picking one greys out the rest), multi-select is answered by number, and multiple questions advance one at a time with per-question timeout.

## Changes

### 1. `QuestionChannel` (`src/features/question-channel.ts`)

Wraps `userQuestions.ask` (instead of `registerProvider`) and routes by `request.agent.id`:

- QQ sessions go through the QQ channel; non-QQ sessions are delegated to the host's default provider (e.g. the web popup), so channels coexist.
- Per-session explicit state machine with three phases: awaiting an answer → advancing question-by-question → done/aborted.
- Abort semantics (`ASK_ABORTED`) cover: `AbortSignal` firing, per-question timeout, session eviction, and channel unload — so upstream callers (e.g. plan-mode) can distinguish "user didn't answer" from send/network errors.
- Sends the first question then suspends a Promise; answers resolve all collected answers once the last question is done.
- Keyboard send failure falls back to plain-text rendering.
- Idempotent install (skips if already patched) and graceful disable when the service is missing or `ask` isn't a function.

### 2. Answer parsing & rendering (pure, testable)

- `answer-parser.ts`: parses a text reply into a structured answer — numeric/separator input selects by index (`1,3` for multi-select), exact label match (case-insensitive), otherwise treated as `custom` text.
- `question-renderer.ts`: builds the inline keyboard for single-select+options questions (2-per-row grid, labels truncated to 10 chars, `group_id` for single-select mutual exclusion) and formats question text with a numbered option list and reply hints. `button_data` encodes `{q, i}` to correlate a click with the currently-active question (stale/late clicks from an earlier question are ignored).

### 3. Answer interception middleware (`src/middleware/question-answer.ts`)

Placed **before** `concurrencyGuard` so answer messages bypass the merge buffer — otherwise "turn waiting for answer ↔ answer buffered" deadlocks. When the text matches a pending question, it calls `tryAnswer` and `ctx.stop('question-answer')`; otherwise it falls through to normal flow.

### 4. Interaction callback (`src/gateway/bootstrap.ts`)

Registers `bot.on('interaction')` to decode button clicks, advance the state machine, and `acknowledgeInteraction` (code `0` when handled, `3` otherwise).

### 5. Lifecycle & timeout

- `SessionManager` holds a `questionChannel` reference and calls `cancelPending(sessionKey)` on eviction so pending promises/closures don't leak.
- New `askTimeoutMs` config (default `300000` = 5 min): each question times out independently with a friendly `⚠️ 提问已超时，未收到回答。` reply.
- `QuestionChannel.uninstall()` rejects all pending entries on plugin unload.

### 6. Misc

- `QQBotSender.sendMarkdown` gains an optional `{ keyboard }` arg (threaded through `outbound-buffer.ts`).
- README / README_EN updated with `askTimeoutMs` and a new "问答互动" feature bullet.

## Configuration

```yaml
askTimeoutMs: 300000   # default 5 min
