### PR TITLE
feat(session): QQ 会话恒注入「提问规约」prompt section（挂官方 assemble 瀑布）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
+## [Unreleased]
+
+### 体验优化
+
+- **QQ 提问规约**：QQ 会话的系统提示新增「QQ 通道提问规范」section（经 `system-prompt/assemble` 瀑布注入），要求模型在让用户做选择/确认/补信息时调用 `ask_user_question` 工具，而不是输出「1. xxx 2. yyy」编号纯文本——编号文本在 QQ 端只能手动输入，工具提问才有可点击按钮。
+
 ## [0.4.0] - 2026-08-16
 
 ### 新功能

--- a/src/session/question-style.test.ts
+++ b/src/session/question-style.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { QUESTION_STYLE_SECTION_NAME, QUESTION_STYLE_SECTION_TEXT } from './question-style.ts';
+
+describe('question-style section', () => {
+  it('mandates ask_user_question for choices', () => {
+    expect(QUESTION_STYLE_SECTION_TEXT).toContain('ask_user_question');
+    // 明确反对编号纯文本列选项（快捷按钮只是兜底，不是目标形态）
+    expect(QUESTION_STYLE_SECTION_TEXT).toContain('编号');
+    // multi_select 克制使用（多选在 QQ 端无按钮，只能手输编号）
+    expect(QUESTION_STYLE_SECTION_TEXT).toContain('multi_select');
+  });
+
+  it('has a stable section name for the assemble waterfall', () => {
+    expect(QUESTION_STYLE_SECTION_NAME).toBe('qqbot:question-style');
+  });
+});

--- a/src/session/question-style.ts
+++ b/src/session/question-style.ts
@@ -1,0 +1,19 @@
+/**
+ * QQ 通道提问规约 prompt section
+ *
+ * 背景：模型在给出选择时，有时直接输出编号文本（如「1. xxx 2. yyy」）
+ * 而不调用 ask_user_question。QQ 问题通道只拦截 ask_user_question 调用
+ * 渲染可点击按钮——编号纯文本只会让用户手动输入，体验倒退，且终端无任何报错。
+ *
+ * 本规约通过 system-prompt/assemble waterfall 注入（见 SessionManager
+ * 的 registerScopePromptInjection，与群聊/私聊附加 prompt 同一订阅），
+ * 明确要求模型：让读者做选择/确认/补信息时必须走 ask_user_question 工具。
+ *
+ * 与出站层的快捷按钮兜底（features/quick-reply.ts）互为表里：
+ * 规约提高工具使用率，快捷按钮兜住漏网之鱼。
+ */
+
+export const QUESTION_STYLE_SECTION_NAME = 'qqbot:question-style';
+
+export const QUESTION_STYLE_SECTION_TEXT = `## QQ 通道提问规范
+需要用户选择、确认操作或补充信息时，一律用 ask_user_question 工具提问（选项 label 简洁；确需多选才设 multi_select 为 true），不要用编号纯文本列选项让用户手动回复。无固定选项的开放式问题可直接文字提问。`;

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -22,6 +22,7 @@ import type { ModelRoute, ModelEntry } from '../model/types.ts';
 import { IdleEvictor } from './idle-evictor.ts';
 import type { QuestionChannel } from '../features/question-channel.ts';
 import type { ApprovalChannel } from '../features/approval-channel.ts';
+import { QUESTION_STYLE_SECTION_NAME, QUESTION_STYLE_SECTION_TEXT } from './question-style.ts';
 import type {
   SessionEventLike,
   DshAgent,
@@ -109,11 +110,16 @@ export class SessionManager {
   }
 
   /**
-   * 通过 system-prompt/assemble waterfall 注入群聊/私聊额外 system prompt。
+   * 通过 system-prompt/assemble waterfall 注入 QQ 会话额外 system prompt：
    *
-   * 该事件在每次 turn 构建 request 时触发；此处按会话 scope（群聊/私聊）
-   * 追加对应的额外 prompt section。会话尚未建立（首次 assemble）或未配置
-   * 额外 prompt 时原样返回，不做改动。
+   * 1. 按会话 scope（群聊/私聊）追加配置的额外 prompt（groupPrompt/directPrompt）；
+   *    未配置时跳过。
+   * 2. 恒追加「QQ 通道提问规范」（question-style）：要求模型让用户做
+   *    选择/确认/补信息时走 ask_user_question 工具，而非编号纯文本——
+   *    问题通道只拦截工具调用渲染按钮，编号文本会退化为手动输入。
+   *
+   * 该事件在每次 turn 构建 request 时触发；会话尚未建立（首次 assemble）
+   * 时原样返回，不做改动。
    */
   private registerScopePromptInjection(): void {
     const assemble = async (
@@ -127,13 +133,15 @@ export class SessionManager {
       const record = this.findByAgent(context.agent);
       if (!record) return assembled;
 
-      const prompt = record.scope === 'group' ? this.config.groupPrompt : this.config.directPrompt;
-      if (!prompt) return assembled;
+      const sections = [...(assembled.sections ?? [])];
 
-      return {
-        ...assembled,
-        sections: [...(assembled.sections ?? []), { name: 'qqbot:scope-prompt', order: 90, text: prompt }],
-      };
+      const prompt = record.scope === 'group' ? this.config.groupPrompt : this.config.directPrompt;
+      if (prompt) sections.push({ name: 'qqbot:scope-prompt', order: 90, text: prompt });
+
+      // order 取大值，排在系统提示尾部更显眼
+      sections.push({ name: QUESTION_STYLE_SECTION_NAME, order: 900, text: QUESTION_STYLE_SECTION_TEXT });
+
+      return { ...assembled, sections };
     };
 
     (this.ctx as unknown as {


### PR DESCRIPTION
QQ 会话恒注入「提问规约」prompt section：要求模型让用户做选择/确认/补信息时用 `ask_user_question` 工具，而不是编号纯文本。

## 行为

QQ 会话（群聊/私聊）每次 turn 的系统提示追加一条「QQ 通道提问规范」section（order 900，排在尾部更显眼）：

- 选择/确认/补信息 → 一律 `ask_user_question` 工具（QQ 端才有可点击按钮）；
- 不要用「1. xxx 2. yyy」编号纯文本列选项（QQ 端只能手动输入）；
- 无固定选项的开放式问题可直接文字提问。

## 与官方实现的关系

直接挂在官方 `235ebc5` 引入的 `system-prompt/assemble` 瀑布上，与群聊/私聊附加 prompt（`groupPrompt`/`directPrompt`）共用同一订阅，不引入新机制。会话无记录（首次 assemble）时原样返回，不做改动。

## 依赖

无。独立审阅、独立合入，不依赖任何其他 PR。

## 背景

模型不一定总调用 `ask_user_question`（被中断后继续推进时尤其常见），会直接输出编号文本——QQ 问题通道只拦截工具调用渲染按钮，编号文本退化为手动输入。本规约与快捷按钮兜底互为表里：规约提高工具使用率，按钮兜住漏网之鱼（快捷按钮在后续独立 PR 提交）。

## 验证

- `tsc --noEmit` ✅
- 新增 2 例测试（section 内容 + 名称稳定）；官方 29 例问题通道测试不受影响。
