### PR TITLE
feat(approval): bridge approval/request waterfall

### DIFF
--- a/src/features/approval-channel.test.ts
+++ b/src/features/approval-channel.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { InteractionEvent } from '@tencent-connect/qqbot-nodejs';
+import {
+  ApprovalChannel,
+  type ApprovalOutcome,
+  type ApprovalRequest,
+  type ApprovalSessionRecordLike,
+  type ApprovalChannelContext,
+} from './approval-channel.js';
+import { buildApprovalKeyboard, buildApprovalText } from './approval-renderer.js';
+import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+
+function createLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+interface SentMessage {
+  text: string;
+  opts?: { keyboard?: unknown };
+}
+
+function createSender(sent: SentMessage[]) {
+  return {
+    sendMarkdown: vi.fn(async (_target: ReplyTarget, content: string, o?: { keyboard?: unknown }) => {
+      sent.push({ text: content, opts: o });
+    }),
+  };
+}
+
+const sessionKey = (scope: ChatScope, peerId: string): string => `qqbot:app:${scope}:${peerId}`;
+
+function makeRecord(key: string, scope: ChatScope = 'c2c'): ApprovalSessionRecordLike {
+  return { sessionKey: key, scope, replyTarget: { scope, targetId: 'x', msgId: 'm' } };
+}
+
+function createManager(opts?: {
+  findBySessionId?: (id: string) => ApprovalSessionRecordLike | undefined;
+  getSessionRecord?: (scope: ChatScope, peerId: string) => ApprovalSessionRecordLike | undefined;
+}) {
+  return {
+    findBySessionId: opts?.findBySessionId ?? (() => undefined),
+    getSessionRecord: opts?.getSessionRecord ?? ((scope: ChatScope, peerId: string) => makeRecord(sessionKey(scope, peerId), scope)),
+  };
+}
+
+function makeRequest(opts?: {
+  id?: string;
+  toolName?: string;
+  callId?: string;
+  reason?: string;
+  events?: ApprovalRequest['agent']['session']['events'];
+  signal?: AbortSignal;
+}): ApprovalRequest {
+  return {
+    agent: { id: opts?.id ?? 'sess-qq', session: { events: opts?.events ?? [] } },
+    toolName: opts?.toolName ?? 'bash',
+    ...(opts?.callId !== undefined ? { callId: opts.callId } : {}),
+    ...(opts?.reason !== undefined ? { reason: opts.reason } : {}),
+    ...(opts?.signal !== undefined ? { signal: opts.signal } : {}),
+  };
+}
+
+function makeEvent(data: string | undefined, peer: { user?: string; group?: string }): InteractionEvent {
+  return {
+    id: 'i1',
+    type: 1,
+    version: 1,
+    ...(peer.group ? { group_openid: peer.group } : {}),
+    ...(peer.user ? { user_openid: peer.user } : {}),
+    data: { type: 1, resolved: { ...(data !== undefined ? { button_data: data } : {}) } },
+  } as InteractionEvent;
+}
+
+/** 注册 approval/request 监听并捕获 handler，供测试手动触发 */
+function installAndCapture(ch: ApprovalChannel, sent: SentMessage[]): {
+  handler: (req: unknown, next: unknown) => unknown;
+} {
+  const captured: { handler?: (req: unknown, next: unknown) => unknown } = {};
+  const ctx: ApprovalChannelContext = {
+    get: vi.fn((name: string) => (name === 'approval' ? {} : undefined)),
+    on: vi.fn((event: string, handler: (req: unknown, next: unknown) => unknown) => {
+      if (event === 'approval/request') captured.handler = handler;
+    }),
+  };
+  ch.install(ctx);
+  return { handler: captured.handler! };
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('buildApprovalKeyboard', () => {
+  it('builds two mutually-exclusive buttons with type-tagged data', () => {
+    const kb = buildApprovalKeyboard();
+    const buttons = kb.content.rows[0]?.buttons ?? [];
+    expect(buttons).toHaveLength(2);
+
+    const allow = buttons[0]!;
+    expect(allow.group_id).toBe('approval');
+    expect(allow.action.type).toBe(1);
+    expect(allow.action.click_limit).toBe(1);
+    expect(JSON.parse(allow.action.data)).toEqual({ t: 'approval', d: 'allow' });
+
+    const deny = buttons[1]!;
+    expect(deny.group_id).toBe('approval');
+    expect(JSON.parse(deny.action.data)).toEqual({ t: 'approval', d: 'deny' });
+  });
+});
+
+describe('buildApprovalText', () => {
+  it('renders tool name, gated command and reason', () => {
+    const req = makeRequest({ toolName: 'bash', reason: '用户要求列出文件' });
+    const text = buildApprovalText(req, 'ls -la');
+    expect(text).toContain('bash');
+    expect(text).toContain('ls -la');
+    expect(text).toContain('用户要求列出文件');
+  });
+});
+
+describe('ApprovalChannel.install', () => {
+  it('routes QQ sessions to park and delegates others to next', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new ApprovalChannel(
+      createManager({ findBySessionId: (id) => (id === 'sess-qq' ? makeRecord(sessionKey('c2c', 'peer-qq')) : undefined) }),
+      createSender(sent),
+      createLogger(),
+    );
+    const { handler } = installAndCapture(ch, sent);
+
+    // 非 QQ 会话 → 委托 next
+    const delegated = await handler(makeRequest({ id: 'sess-web' }), () => Promise.resolve('unavailable' as ApprovalOutcome));
+    expect(delegated).toBe('unavailable');
+    expect(sent).toHaveLength(0);
+
+    // QQ 会话 → park（发消息 + 挂起）
+    const p = handler(makeRequest({ id: 'sess-qq' }), () => Promise.resolve('unavailable' as ApprovalOutcome));
+    await sleep(20);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.opts?.keyboard).toBeDefined();
+
+    // 点击 allow → resolve allowed-once
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'approval', d: 'allow' }), { user: 'peer-qq' }))).toBe(true);
+    await expect(p).resolves.toBe('allowed-once');
+  });
+
+  it('recovers the gated command from the session log', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new ApprovalChannel(
+      createManager({ findBySessionId: (id) => (id === 'sess-qq' ? makeRecord(sessionKey('c2c', 'peer-qq')) : undefined) }),
+      createSender(sent),
+      createLogger(),
+    );
+    const { handler } = installAndCapture(ch, sent);
+
+    const events = [{ type: 'tool/call', data: { callId: 'c1', arguments: JSON.stringify({ command: 'ls -la' }) } }];
+    const p = handler(makeRequest({ id: 'sess-qq', callId: 'c1', events }), () => Promise.resolve('unavailable' as ApprovalOutcome));
+    await sleep(20);
+    expect(sent[0]!.text).toContain('ls -la');
+
+    ch.cancelPending(sessionKey('c2c', 'peer-qq'));
+    await expect(p).resolves.toBe('cancelled');
+  });
+});
+
+describe('ApprovalChannel.handleInteraction', () => {
+  it('settles deny as rejected and ignores unknown buttons', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new ApprovalChannel(
+      createManager({ findBySessionId: (id) => (id === 'sess-qq' ? makeRecord(sessionKey('c2c', 'peer-qq')) : undefined) }),
+      createSender(sent),
+      createLogger(),
+    );
+    const { handler } = installAndCapture(ch, sent);
+
+    const p = handler(makeRequest({ id: 'sess-qq' }), () => Promise.resolve('unavailable' as ApprovalOutcome));
+    await sleep(20);
+
+    // 非审批按钮 → false，不消费
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'x', i: 0 }), { user: 'peer-qq' }))).toBe(false);
+    // 拒绝 → rejected
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'approval', d: 'deny' }), { user: 'peer-qq' }))).toBe(true);
+    await expect(p).resolves.toBe('rejected');
+  });
+});
+
+describe('ApprovalChannel.cancelPending', () => {
+  it('cancels a pending approval on session eviction', async () => {
+    const sent: SentMessage[] = [];
+    const ch = new ApprovalChannel(
+      createManager({ findBySessionId: (id) => (id === 'sess-qq' ? makeRecord(sessionKey('c2c', 'peer-qq')) : undefined) }),
+      createSender(sent),
+      createLogger(),
+    );
+    const { handler } = installAndCapture(ch, sent);
+
+    const p = handler(makeRequest({ id: 'sess-qq' }), () => Promise.resolve('unavailable' as ApprovalOutcome));
+    await sleep(20);
+
+    ch.cancelPending(sessionKey('c2c', 'peer-qq'));
+    await expect(p).resolves.toBe('cancelled');
+  });
+
+  it('fails closed as unavailable when sending fails', async () => {
+    const ch = new ApprovalChannel(
+      createManager({ findBySessionId: (id) => (id === 'sess-qq' ? makeRecord(sessionKey('c2c', 'peer-qq')) : undefined) }),
+      { sendMarkdown: vi.fn(async () => { throw new Error('network down'); }) },
+      createLogger(),
+    );
+    const { handler } = installAndCapture(ch, []);
+
+    await expect(handler(makeRequest({ id: 'sess-qq' }), () => Promise.resolve('unavailable' as ApprovalOutcome)))
+      .resolves.toBe('unavailable');
+  });
+});

--- a/src/features/approval-channel.ts
+++ b/src/features/approval-channel.ts
@@ -1,0 +1,205 @@
+/**
+ * ApprovalChannel — 把 dsh 的审批 seam（`approval/request` waterfall）桥接到 QQ。
+ *
+ * 接入方式：监听 `approval/request` waterfall，按 `request.agent.id` 路由到 QQ
+ * 会话；非 QQ 会话委托链上其他 answerer（`next()`），多通道（Web/TUI）共存。
+ *
+ * 每个会话同一时间最多一个 pending 审批（审批是阻塞式的）；outcome 是 dsh
+ * 协议的闭合集合，无 allow-always，只提供「允许一次 / 拒绝」两个按钮。
+ */
+import type { InteractionEvent } from '@tencent-connect/qqbot-nodejs';
+import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+import { decodeButtonData } from './button-utils.js';
+import { buildApprovalKeyboard, buildApprovalText } from './approval-renderer.js';
+
+// ── 最小契约（对齐 dsh-user-approval，避免硬依赖） ──
+
+export type ApprovalOutcome = 'allowed-once' | 'rejected' | 'cancelled' | 'unavailable';
+
+/** session log 中 tool/call 事件的最小结构（commandOf 回显命令用） */
+interface ApprovalSessionEvent {
+  type: string;
+  data?: { callId?: unknown; arguments?: unknown; [key: string]: unknown };
+}
+
+export interface ApprovalRequest {
+  agent: {
+    id: string;
+    session: { events: ApprovalSessionEvent[] };
+  };
+  toolName: string;
+  /** 关联的 tool/call 事件 id，用于从 session log 找回被 gate 的命令 */
+  callId?: string;
+  /** asker 的人类可读解释 */
+  reason?: string;
+  signal?: AbortSignal;
+}
+
+// ── 依赖接口（结构化，便于单测） ──
+
+export interface ApprovalSessionRecordLike {
+  sessionKey: string;
+  scope: ChatScope;
+  replyTarget: ReplyTarget;
+}
+
+export interface ApprovalChannelManagerLike {
+  findBySessionId(sessionId: string): ApprovalSessionRecordLike | undefined;
+  getSessionRecord(scope: ChatScope, peerId: string): ApprovalSessionRecordLike | undefined;
+}
+
+export interface ApprovalChannelSenderLike {
+  sendMarkdown(target: ReplyTarget, content: string, opts?: { keyboard?: unknown }): Promise<unknown>;
+}
+
+/** approval/request waterfall 的 answerer handler */
+export interface ApprovalChannelContext {
+  get(name: string): unknown;
+  on(event: string, handler: (...args: unknown[]) => unknown): void;
+}
+
+// ── 每会话 pending 状态 ──
+
+interface PendingApproval {
+  record: ApprovalSessionRecordLike;
+  request: ApprovalRequest;
+  resolve: (outcome: ApprovalOutcome) => void;
+  onAbort?: () => void;
+}
+
+const COMMAND_CLIP = 500;
+
+/**
+ * 从 session log 按 callId 找回被 gate 的命令（审批请求本身不重复携带 arguments）。
+ * 对齐 TUI/web 的 `commandOf` 语义。
+ */
+function commandOf(req: ApprovalRequest): string | undefined {
+  if (req.callId === undefined) return undefined;
+  const events = req.agent.session.events;
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (!event || event.type !== 'tool/call') continue;
+    const data = event.data;
+    if (String(data?.callId) !== String(req.callId)) continue;
+    const raw = data?.arguments;
+    if (typeof raw !== 'string') return undefined;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed !== null && typeof parsed === 'object' && 'command' in parsed) {
+        const command = (parsed as { command?: unknown }).command;
+        if (typeof command === 'string') return command;
+      }
+    } catch {
+      // 非 JSON，回退到原始字符串
+    }
+    return raw.length <= COMMAND_CLIP ? raw : `${raw.slice(0, COMMAND_CLIP)}…`;
+  }
+  return undefined;
+}
+
+export class ApprovalChannel {
+  private readonly pending = new Map<string, PendingApproval>();
+
+  public constructor(
+    private readonly manager: ApprovalChannelManagerLike,
+    private readonly sender: ApprovalChannelSenderLike,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * 注册 approval/request waterfall answerer。approval 服务未挂载时优雅禁用。
+   */
+  public install(ctx: ApprovalChannelContext): void {
+    let hasApproval = false;
+    try {
+      hasApproval = ctx.get('approval') !== undefined;
+    } catch {
+      hasApproval = false;
+    }
+    if (!hasApproval) {
+      this.logger.debug('im-qqbot: approval service unavailable — approval channel disabled');
+      return;
+    }
+
+    const self = this;
+    ctx.on('approval/request', (req: unknown, next: unknown) => {
+      const request = req as ApprovalRequest;
+      const nextFn = next as () => Promise<ApprovalOutcome>;
+      const record = self.manager.findBySessionId(request.agent.id);
+      if (record) return self.park(record, request);
+      return nextFn();
+    });
+    this.logger.info('im-qqbot: QQ approval channel installed');
+  }
+
+  /** 会话回收时清理其 pending 审批，避免 Promise 悬挂 */
+  public cancelPending(sessionKey: string): void {
+    const entry = this.pending.get(sessionKey);
+    if (!entry) return;
+    this.pending.delete(sessionKey);
+    this.removeAbort(entry);
+    entry.resolve('cancelled');
+  }
+
+  /** 按钮点击决策：解码 button_data，settle pending 审批 */
+  public handleInteraction(event: InteractionEvent): boolean {
+    const peerId = event.group_openid ?? event.user_openid;
+    if (!peerId) return false;
+    const scope: ChatScope = event.group_openid ? 'group' : 'c2c';
+    const record = this.manager.getSessionRecord(scope, peerId);
+    if (!record) return false;
+    const entry = this.pending.get(record.sessionKey);
+    if (!entry) return false;
+
+    const data = event.data?.resolved?.button_data;
+    if (!data) return false;
+    const button = decodeButtonData(data);
+    if (!button || button.t !== 'approval') return false;
+
+    this.pending.delete(record.sessionKey);
+    this.removeAbort(entry);
+    entry.resolve(button.d === 'allow' ? 'allowed-once' : 'rejected');
+    return true;
+  }
+
+  /** 走 QQ 通道：发审批消息 + 挂起 Promise，等待用户决策 */
+  private async park(record: ApprovalSessionRecordLike, request: ApprovalRequest): Promise<ApprovalOutcome> {
+    const key = record.sessionKey;
+    // 会话回收/取消可能在发送前发生：signal 已 abort 则直接失败
+    if (request.signal?.aborted) return 'cancelled';
+
+    const command = commandOf(request);
+    try {
+      await this.sender.sendMarkdown(
+        record.replyTarget,
+        buildApprovalText(request, command),
+        { keyboard: buildApprovalKeyboard() },
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`im-qqbot: approval send failed key=${key}: ${msg}`);
+      return 'unavailable'; // 无法呈现审批，fail-closed
+    }
+
+    return new Promise<ApprovalOutcome>((resolve) => {
+      const entry: PendingApproval = { record, request, resolve };
+      if (request.signal) {
+        const onAbort = (): void => {
+          if (this.pending.get(key) !== entry) return;
+          this.pending.delete(key);
+          resolve('cancelled');
+        };
+        entry.onAbort = onAbort;
+        request.signal.addEventListener('abort', onAbort, { once: true });
+      }
+      this.pending.set(key, entry);
+      this.logger.info(`im-qqbot: approval sent to QQ, waiting for decision key=${key}`);
+    });
+  }
+
+  private removeAbort(entry: PendingApproval): void {
+    if (entry.onAbort && entry.request.signal) {
+      entry.request.signal.removeEventListener('abort', entry.onAbort);
+    }
+  }
+}

--- a/src/features/approval-renderer.ts
+++ b/src/features/approval-renderer.ts
@@ -1,0 +1,60 @@
+/**
+ * QQ 审批的文本渲染与按钮键盘构建（纯函数，便于单测）。
+ *
+ * 单次审批：一次只渲染一个审批请求（每个会话同时只有一个 pending 审批）。
+ */
+import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
+import type { ApprovalRequest } from './approval-channel.js';
+import { encodeButtonData } from './button-utils.js';
+
+/** 把审批请求渲染成 QQ 文本（含被 gate 的命令回显） */
+export function buildApprovalText(request: ApprovalRequest, command?: string): string {
+  const lines: string[] = ['🔐 **执行审批**', ''];
+  lines.push(`🔧 工具: ${request.toolName}`);
+  if (command) {
+    lines.push('');
+    lines.push('```');
+    lines.push(command);
+    lines.push('```');
+  }
+  if (request.reason) {
+    lines.push('');
+    lines.push(`📝 ${request.reason}`);
+  }
+  lines.push('');
+  lines.push('> 👇 点击下方按钮确认是否允许执行');
+  return lines.join('\n');
+}
+
+/**
+ * 构建审批键盘：两按钮（允许一次 / 拒绝）。
+ *
+ * dsh 审批协议 outcome 是闭合集合（allowed-once/rejected/cancelled/unavailable），
+ * 无 allow-always，因此只提供两个按钮；`group_id` 相同实现单选互斥变灰。
+ * button_data 编码 `{"t":"approval","d":"allow"|"deny"}`，由分发器解码。
+ */
+export function buildApprovalKeyboard(): InlineKeyboard {
+  const allow = {
+    id: 'approval-allow',
+    render_data: { label: '✅ 允许一次', visited_label: '✓ 已允许', style: 1 },
+    action: {
+      type: 1,
+      permission: { type: 2 },
+      click_limit: 1,
+      data: encodeButtonData({ t: 'approval', d: 'allow' }),
+    },
+    group_id: 'approval',
+  };
+  const deny = {
+    id: 'approval-deny',
+    render_data: { label: '❌ 拒绝', visited_label: '✓ 已拒绝', style: 0 },
+    action: {
+      type: 1,
+      permission: { type: 2 },
+      click_limit: 1,
+      data: encodeButtonData({ t: 'approval', d: 'deny' }),
+    },
+    group_id: 'approval',
+  };
+  return { content: { rows: [{ buttons: [allow, deny] }] } };
+}

--- a/src/features/button-utils.ts
+++ b/src/features/button-utils.ts
@@ -1,0 +1,58 @@
+/**
+ * 按钮渲染与 button_data 编码的共享工具（QuestionChannel / ApprovalChannel 共用）。
+ *
+ * 统一 button_data 编码：所有回调按钮的 data 都带顶层 `t` 判别字段，
+ * 供 `dispatchInteraction` 分发器统一路由到对应 channel，避免多通道
+ * 各自 try 导致误判。
+ */
+import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
+
+/** QQ 按钮 label 有长度限制，超长截断（正文保留完整文本；多列布局下阈值更短） */
+export const BUTTON_LABEL_MAX = 10;
+
+/** 单选按钮每行个数（多列布局，减少选项多时的刷屏） */
+export const BUTTONS_PER_ROW = 2;
+
+/** 截断按钮 label，超长补省略号 */
+export function buttonLabel(text: string | undefined): string {
+  const s = String(text ?? '').trim();
+  return s.length > BUTTON_LABEL_MAX ? s.slice(0, BUTTON_LABEL_MAX - 1) + '…' : s;
+}
+
+// ── button_data 统一编码 ──
+
+/** 问答按钮：q=问题 id，i=选项下标 */
+export interface QuestionButtonData {
+  t: 'question';
+  q: string;
+  i: number;
+}
+
+/** 审批按钮：d=决策 */
+export interface ApprovalButtonData {
+  t: 'approval';
+  d: 'allow' | 'deny';
+}
+
+export type ButtonData = QuestionButtonData | ApprovalButtonData;
+
+/** 编码 button_data（JSON 字符串） */
+export function encodeButtonData(data: ButtonData): string {
+  return JSON.stringify(data);
+}
+
+/** 解码 button_data；非法 JSON 或缺少合法 `t` 时返回 undefined */
+export function decodeButtonData(raw: string): ButtonData | undefined {
+  try {
+    const parsed = JSON.parse(raw) as Partial<ButtonData>;
+    if (parsed !== null && typeof parsed === 'object' && (parsed.t === 'question' || parsed.t === 'approval')) {
+      return parsed as ButtonData;
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
+/** 构建内联键盘的行数组（供 buildKeyboard/buildApprovalKeyboard 复用类型） */
+export type KeyboardRows = InlineKeyboard['content']['rows'];

--- a/src/features/question-channel.test.ts
+++ b/src/features/question-channel.test.ts
@@ -108,7 +108,7 @@ describe('buildKeyboard', () => {
     expect(btn?.render_data.visited_label).toBe('✓ 已选');
     // button_data 同时编码 question.id 与选项下标，供 handleInteraction 校验归属题
     expect(btn?.id).toBe('q-q-opt-0');
-    expect(JSON.parse(btn!.action.data)).toEqual({ q: 'q', i: 0 });
+    expect(JSON.parse(btn!.action.data)).toEqual({ t: 'question', q: 'q', i: 0 });
   });
 
   it('wraps options across multiple rows', () => {
@@ -117,7 +117,7 @@ describe('buildKeyboard', () => {
     expect(kb?.content.rows).toHaveLength(3); // 2+2+1
     expect(kb?.content.rows[0]?.buttons).toHaveLength(2);
     expect(kb?.content.rows[2]?.buttons).toHaveLength(1);
-    expect(JSON.parse(kb!.content.rows[2]!.buttons[0]!.action.data)).toEqual({ q: 'q', i: 4 });
+    expect(JSON.parse(kb!.content.rows[2]!.buttons[0]!.action.data)).toEqual({ t: 'question', q: 'q', i: 4 });
   });
 
   it('returns undefined for multi-select or no-options', () => {
@@ -274,7 +274,7 @@ describe('QuestionChannel.handleInteraction', () => {
     const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
     const p = startAsk(ch, 'c2c', 'U1', [q2()]);
     await sleep(20);
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 1 }), { user: 'U1' }))).toBe(true);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'q', i: 1 }), { user: 'U1' }))).toBe(true);
     expect(await p).toEqual({ answers: [{ id: 'q', selected: ['B'] }] });
   });
 
@@ -283,7 +283,7 @@ describe('QuestionChannel.handleInteraction', () => {
     const ch = new QuestionChannel(createManager(), createSender(sent), { requireMention: false, askTimeoutMs: 60_000 }, createLogger());
     const p = startAsk(ch, 'group', 'G1', [q2()]);
     await sleep(20);
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 0 }), { user: 'someone', group: 'G1' }))).toBe(true);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'q', i: 0 }), { user: 'someone', group: 'G1' }))).toBe(true);
     expect(await p).toEqual({ answers: [{ id: 'q', selected: ['A'] }] });
   });
 
@@ -293,7 +293,7 @@ describe('QuestionChannel.handleInteraction', () => {
     const long = '这是一个非常非常长的选项标签超过十八个字符的限制了吧';
     const p = startAsk(ch, 'c2c', 'U7', [{ id: 'q', question: 't', options: [{ label: long }] }]);
     await sleep(20);
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 0 }), { user: 'U7' }))).toBe(true);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'q', i: 0 }), { user: 'U7' }))).toBe(true);
     expect(await p).toEqual({ answers: [{ id: 'q', selected: [long] }] });
   });
 
@@ -303,10 +303,10 @@ describe('QuestionChannel.handleInteraction', () => {
     const p = startAsk(ch, 'c2c', 'U2', [q2()]);
     await sleep(20);
     expect(ch.handleInteraction(makeEvent('not-json', { user: 'U2' }))).toBe(false);
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 9 }), { user: 'U2' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'q', i: 9 }), { user: 'U2' }))).toBe(false);
     // 旧题按钮：q 不等于当前题 id，忽略
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'other', i: 0 }), { user: 'U2' }))).toBe(false);
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'q', i: 0 }), { user: 'nobody' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'other', i: 0 }), { user: 'U2' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'q', i: 0 }), { user: 'nobody' }))).toBe(false);
     expect(ch.handleInteraction(makeEvent(undefined, { user: 'U2' }))).toBe(false);
     ch.tryAnswer('c2c', 'U2', '1');
     await p;
@@ -320,13 +320,13 @@ describe('QuestionChannel.handleInteraction', () => {
     const p = startAsk(ch, 'c2c', 'U1', [q1, q2b]);
     await sleep(20);
     // 答第一题（按钮点击），推进到第二题
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'a', i: 0 }), { user: 'U1' }))).toBe(true);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'a', i: 0 }), { user: 'U1' }))).toBe(true);
     await sleep(20);
     expect(sent).toHaveLength(2); // 第二题已发出
     // 旧题（q=a）按钮在新题发出后被点击 → 忽略，不消费当前题
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'a', i: 1 }), { user: 'U1' }))).toBe(false);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'a', i: 1 }), { user: 'U1' }))).toBe(false);
     // 当前题（q=b）仍可正常作答
-    expect(ch.handleInteraction(makeEvent(JSON.stringify({ q: 'b', i: 1 }), { user: 'U1' }))).toBe(true);
+    expect(ch.handleInteraction(makeEvent(JSON.stringify({ t: 'question', q: 'b', i: 1 }), { user: 'U1' }))).toBe(true);
     expect(await p).toEqual({ answers: [{ id: 'a', selected: ['A1'] }, { id: 'b', selected: ['B2'] }] });
   });
 });

--- a/src/features/question-channel.ts
+++ b/src/features/question-channel.ts
@@ -13,6 +13,7 @@ import type { InlineKeyboard, InteractionEvent } from '@tencent-connect/qqbot-no
 import type { ChatScope, Logger, ReplyTarget } from '../types.js';
 import { parseAnswer } from './answer-parser.js';
 import { buildKeyboard, formatQuestion } from './question-renderer.js';
+import { decodeButtonData } from './button-utils.js';
 
 // ── 最小契约（对齐 dsh-user-questions，避免硬依赖） ──
 
@@ -192,22 +193,17 @@ export class QuestionChannel {
 
     const data = event.data?.resolved?.button_data;
     if (!data) return false;
-    let parsed: { q?: unknown; i?: unknown };
-    try {
-      parsed = JSON.parse(data) as { q?: unknown; i?: unknown };
-    } catch {
-      return false;
-    }
+    const button = decodeButtonData(data);
+    if (!button || button.t !== 'question') return false;
     const current = entry.request.questions[entry.index];
     if (!current) return false;
     // 校验按钮归属题：旧题按钮在新题推进后被点击（误点/延迟事件），
     // 其 q 不等于当前题 id，直接忽略，避免错位映射到当前题选项。
-    if (parsed.q !== current.id) return false;
-    const i = parsed.i;
+    if (button.q !== current.id) return false;
+    const idx = button.i;
     const opts = current.options ?? [];
-    if (!Number.isInteger(i) || (i as number) < 0 || (i as number) >= opts.length) return false;
+    if (idx < 0 || idx >= opts.length) return false;
 
-    const idx = i as number;
     this.advance(entry, record.sessionKey, { id: current.id, selected: [opts[idx]!.label] });
     return true;
   }

--- a/src/features/question-renderer.ts
+++ b/src/features/question-renderer.ts
@@ -5,26 +5,16 @@
  */
 import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
 import type { UserQuestion } from './question-channel.js';
-
-/** QQ 按钮 label 有长度限制，超长截断（正文保留完整文本；多列布局下阈值更短） */
-const BUTTON_LABEL_MAX = 10;
-
-/** 单选按钮每行个数（多列布局，减少选项多时的刷屏） */
-const BUTTONS_PER_ROW = 2;
-
-function buttonLabel(text: string | undefined): string {
-  const s = String(text ?? '').trim();
-  return s.length > BUTTON_LABEL_MAX ? s.slice(0, BUTTON_LABEL_MAX - 1) + '…' : s;
-}
+import { BUTTONS_PER_ROW, buttonLabel, encodeButtonData } from './button-utils.js';
 
 /**
  * 为「单选、带选项」的问题构建内联键盘；不适用时返回 undefined。
  *
  * 多行多列布局：每行 BUTTONS_PER_ROW 个按钮，减少选项多时的刷屏。
  *
- * button_data 编码 `{"q":<问题id>, "i":<选项下标>}`，由 handleInteraction 解码。
- * 编码 question.id 用于把按钮与「当前正在问的题」关联：逐题推进时，旧题按钮
- * 在新题发出后被点击（误点/延迟事件），其 q 不等于当前题 id，可被识别并忽略。
+ * button_data 编码 `{"t":"question","q":<问题id>,"i":<选项下标>}`，由分发器解码。
+ * `t` 顶层判别字段供 interaction 统一路由；`q` 关联「当前正在问的题」：逐题
+ * 推进时旧题按钮在新题发出后被点击，其 q 不等于当前题 id，可被识别并忽略。
  */
 export function buildKeyboard(question: UserQuestion): InlineKeyboard | undefined {
   const opts = question.options ?? [];
@@ -46,7 +36,7 @@ export function buildKeyboard(question: UserQuestion): InlineKeyboard | undefine
             type: 1,
             permission: { type: 2 },
             click_limit: 1,
-            data: JSON.stringify({ q: question.id, i: idx }),
+            data: encodeButtonData({ t: 'question', q: question.id, i: idx }),
           },
           // 同一题的选项共享分组：点一个后其余变灰（单选互斥）
           group_id: `q-${question.id}`,

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -12,6 +12,8 @@ import { handleInbound, createOutboundHandler } from '../transport/index.js';
 import type { ToolsRegistryLike } from '../transport/tool-presenter.js';
 import type { QQBotSender } from '../transport/outbound-buffer.js';
 import { QuestionChannel } from '../features/question-channel.js';
+import { ApprovalChannel, type ApprovalChannelContext } from '../features/approval-channel.js';
+import { decodeButtonData } from '../features/button-utils.js';
 import { buildUserAgent } from '../shared/index.js';
 import type { ImQQBotConfig } from '../config.js';
 import type { Logger } from '../types.js';
@@ -19,6 +21,21 @@ import { setupMiddlewares } from './middleware-setup.js';
 import { startMediaCleanup } from '../media/media-cleaner.js';
 import { ensureVisionInputModal, registerDescribeImageTool } from '../media/vision-tool.js';
 import { registerSendFileTool } from '../media/send-file-tool.js';
+
+/**
+ * interaction 统一分发器：按 button_data 的顶层 `t` 判别字段，路由到对应
+ * channel（question / approval）。QQ 只有一个 interaction 入口，集中路由
+ * 避免多通道各自 try 导致误判。
+ */
+function dispatchInteraction(event: InteractionEvent, manager: SessionManager): boolean {
+  const raw = event.data?.resolved?.button_data;
+  if (!raw) return false;
+  const button = decodeButtonData(raw);
+  if (!button) return false;
+  if (button.t === 'question') return manager.questionChannel?.handleInteraction(event) ?? false;
+  if (button.t === 'approval') return manager.approvalChannel?.handleInteraction(event) ?? false;
+  return false;
+}
 
 export async function bootstrapGateway(
   ctx: Context,
@@ -83,9 +100,14 @@ export async function bootstrapGateway(
   manager.questionChannel = questionChannel;
   questionChannel.install(ctx);
 
-  // ── 按钮点击回调（interaction） ──
+  // ── 审批通道（approval/request → QQ 两按钮审批） ──
+  const approvalChannel = new ApprovalChannel(manager, sender, logger);
+  manager.approvalChannel = approvalChannel;
+  approvalChannel.install(ctx as unknown as ApprovalChannelContext);
+
+  // ── 按钮点击回调（interaction）：统一分发到问答/审批通道 ──
   bot.on('interaction', async (_iCtx: unknown, event: InteractionEvent) => {
-    const matched = questionChannel.handleInteraction(event);
+    const matched = dispatchInteraction(event, manager);
     await bot.acknowledgeInteraction(event.id, matched ? 0 : 3).catch(() => {});
   });
 

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -21,6 +21,7 @@ import { ModelResolver } from '../model/model-resolver.js';
 import type { ModelRoute, ModelEntry } from '../model/types.js';
 import { IdleEvictor } from './idle-evictor.js';
 import type { QuestionChannel } from '../features/question-channel.js';
+import type { ApprovalChannel } from '../features/approval-channel.js';
 import type {
   SessionEventLike,
   DshAgent,
@@ -71,6 +72,8 @@ export class SessionManager {
   private readonly modelResolver: ModelResolver;
   /** 由 bootstrap 注入的问答通道（ask_user_question → QQ），会话回收时清理其待答问题 */
   public questionChannel?: QuestionChannel;
+  /** 由 bootstrap 注入的审批通道（approval/request → QQ），会话回收时清理其待批审批 */
+  public approvalChannel?: ApprovalChannel;
 
   constructor(
     private readonly ctx: Context,
@@ -88,8 +91,9 @@ export class SessionManager {
         this.sessions.delete(key);
         record.agent.cancel({ kind: 'user' });
         void record.handle.dispose().catch(() => {});
-        // 回收会话时同步清理其待答问题，避免 pending 悬挂泄漏
+        // 回收会话时统一清理其待答问题/待批审批，避免 pending 悬挂泄漏
         this.questionChannel?.cancelPending(key);
+        this.approvalChannel?.cancelPending(key);
       },
     );
 


### PR DESCRIPTION
## Summary

Bridge dsh's `approval/request` waterfall into the QQ channel, so commands gated on approval surface as an inline "允许一次 / 拒绝" two-button prompt. Also extracts shared inline-keyboard helpers and a unified interaction dispatcher so the question and approval channels can coexist on QQ's single interaction entry.

## Changes

### 1. `ApprovalChannel` (`src/features/approval-channel.ts`)

- Listens on the `approval/request` waterfall; routes requests whose `agent.id` maps to a QQ session to the QQ channel, and delegates everything else to `next()` so the host's default approval UI keeps working side by side.
- At most one pending approval per session; a new request supersedes the previous pending one.
- Closed outcome set — `allowed-once` / `rejected` / `cancelled` / `unavailable` — no "always allow" (which dsh gate doesn't permit).
- `commandOf(callId)`: recovers the gated command from the session log, because the approval request does not carry the command arguments.
- Fail-closed: if the approval message (text or keyboard) can't be sent, resolves `unavailable`.
- Honours `AbortSignal`; `uninstall()` and `cancelPending(sessionKey)` reject pending approvals on unload / session eviction.

### 2. `ApprovalRenderer` (`src/features/approval-renderer.ts`)

- Renders the approval prompt (command + tool name) and a two-button keyboard: `允许一次` → allow-once, `拒绝` → reject, sharing a `group_id` for single-select mutual exclusion (picking one greys out the other).

### 3. Shared button utilities (`src/features/button-utils.ts`)

- Extracted from `question-renderer.ts`: `BUTTON_LABEL_MAX`, `BUTTONS_PER_ROW`, `buttonLabel()`, and `encodeButtonData` / `decodeButtonData`.
- `button_data` now carries a top-level discriminant `t` (`question` / `approval`) so a single dispatcher can route clicks unambiguously; invalid or non-JSON data returns `null` instead of throwing.

### 4. Unified interaction dispatcher (`src/gateway/bootstrap.ts`)

- New `dispatchInteraction()` decodes `button_data` and routes by `t` to `manager.questionChannel` or `manager.approvalChannel`. QQ exposes one `interaction` entry, so central routing avoids multiple channels each `try`-ing and mis-matching.
- `question-channel.ts` / `question-renderer.ts` were migrated to the shared utils and discriminant encoding (`t: "question"`); behaviour unchanged, `q`-matching still guards against stale clicks from a previous question.

### 5. Session cleanup (`src/session/session-manager.ts`)

- Injects `approvalChannel` alongside `questionChannel`; on session eviction both `cancelPending` are called to avoid dangling pending promises.