### PR TITLE
refactor: use .ts import extensions

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -4,8 +4,8 @@
  * 通用能力：对应底层 dsh agent 能力（new/compact/model/stop），无前缀
  * QQBot 特有：插件自身封装（bot-ping/bot-version/bot-status/bot-help），带 bot- 前缀
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { sendMarkdownChunked, PLUGIN_VERSION } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { sendMarkdownChunked, PLUGIN_VERSION } from '../shared/index.ts';
 
 /** /bot-help — 分组查看所有指令 */
 export function helpCommand(

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,13 +7,13 @@
  *   - agent：底层 dsh agent 通用能力（new/compact/model/stop）
  *   - qqbot：插件自身特有（ping/version/status/help）
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { newCommand, compactCommand } from './session.js';
-import { modelCommand } from './model.js';
-import { presetCommand } from './preset.js';
-import { statusCommand } from './status.js';
-import { helpCommand } from './help.js';
-import { pingCommand, versionCommand, stopCommand } from './misc.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { newCommand, compactCommand } from './session.ts';
+import { modelCommand } from './model.ts';
+import { presetCommand } from './preset.ts';
+import { statusCommand } from './status.ts';
+import { helpCommand } from './help.ts';
+import { pingCommand, versionCommand, stopCommand } from './misc.ts';
 
 /**
  * 构建标准命令列表

--- a/src/commands/misc.ts
+++ b/src/commands/misc.ts
@@ -4,8 +4,8 @@
  * - /bot-ping /bot-version：QQBot 插件特有（连通性测试、版本信息）
  * - /stop：中止当前生成（对应底层 agent cancel，通用能力）
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { getScopePeer, PLUGIN_VERSION } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { getScopePeer, PLUGIN_VERSION } from '../shared/index.ts';
 
 /** /bot-ping — 连通性测试 */
 export function pingCommand(): CategorizedCommand {

--- a/src/commands/model.ts
+++ b/src/commands/model.ts
@@ -1,8 +1,8 @@
 /**
  * 模型命令：/model — 查看或切换模型
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { getScopePeer, sendMarkdownChunked } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { getScopePeer, sendMarkdownChunked } from '../shared/index.ts';
 
 export function modelCommand({ manager, config }: CommandDeps): CategorizedCommand {
   return {

--- a/src/commands/preset.ts
+++ b/src/commands/preset.ts
@@ -3,8 +3,8 @@
  *
  * 无参数列出可用 preset（可点击切换），有参数切换，reset/default 重置为默认。
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { getScopePeer, sendMarkdownChunked } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { getScopePeer, sendMarkdownChunked } from '../shared/index.ts';
 
 export function presetCommand({ manager, config }: CommandDeps): CategorizedCommand {
   return {

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -6,8 +6,8 @@
  *
  * 两者都对应底层 dsh agent 能力，分类为 agent（通用能力）。
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { getScopePeer } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { getScopePeer } from '../shared/index.ts';
 
 /** /new（别名 /reset /clear）— 开始新会话 */
 export function newCommand({ manager }: CommandDeps): CategorizedCommand {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,8 +1,8 @@
 /**
  * 状态命令：/bot-status（QQBot 特有）
  */
-import type { CommandDeps, CategorizedCommand } from './types.js';
-import { getScopePeer, formatRelativeTime } from '../shared/index.js';
+import type { CommandDeps, CategorizedCommand } from './types.ts';
+import { getScopePeer, formatRelativeTime } from '../shared/index.ts';
 
 /** /bot-status — 查看当前会话状态 */
 export function statusCommand({ manager }: CommandDeps): CategorizedCommand {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -4,8 +4,8 @@
  * 每个命令工厂函数接收 CommandDeps，由 commands/index.ts 统一注入。
  */
 import type { SlashCommand } from '@tencent-connect/qqbot-nodejs';
-import type { SessionManager } from '../session/index.js';
-import type { ImQQBotConfig } from '../config.js';
+import type { SessionManager } from '../session/index.ts';
+import type { ImQQBotConfig } from '../config.ts';
 
 export interface CommandDeps {
   manager: SessionManager;

--- a/src/features/answer-parser.ts
+++ b/src/features/answer-parser.ts
@@ -3,7 +3,7 @@
  *
  * 逐题解析：一次解析一个问题的答案。
  */
-import type { UserQuestion, UserQuestionAnswer } from './question-channel.js';
+import type { UserQuestion, UserQuestionAnswer } from './question-channel.ts';
 
 /** 把用户对单个问题的文本回复解析为答案 */
 export function parseAnswer(question: UserQuestion, text: string): UserQuestionAnswer {

--- a/src/features/approval-channel.test.ts
+++ b/src/features/approval-channel.test.ts
@@ -6,9 +6,9 @@ import {
   type ApprovalRequest,
   type ApprovalSessionRecordLike,
   type ApprovalChannelContext,
-} from './approval-channel.js';
-import { buildApprovalKeyboard, buildApprovalText } from './approval-renderer.js';
-import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+} from './approval-channel.ts';
+import { buildApprovalKeyboard, buildApprovalText } from './approval-renderer.ts';
+import type { ChatScope, Logger, ReplyTarget } from '../types.ts';
 
 function createLogger(): Logger {
   return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/src/features/approval-channel.ts
+++ b/src/features/approval-channel.ts
@@ -8,9 +8,9 @@
  * 协议的闭合集合，无 allow-always，只提供「允许一次 / 拒绝」两个按钮。
  */
 import type { InteractionEvent } from '@tencent-connect/qqbot-nodejs';
-import type { ChatScope, Logger, ReplyTarget } from '../types.js';
-import { decodeButtonData } from './button-utils.js';
-import { buildApprovalKeyboard, buildApprovalText } from './approval-renderer.js';
+import type { ChatScope, Logger, ReplyTarget } from '../types.ts';
+import { decodeButtonData } from './button-utils.ts';
+import { buildApprovalKeyboard, buildApprovalText } from './approval-renderer.ts';
 
 // ── 最小契约（对齐 dsh-user-approval，避免硬依赖） ──
 
@@ -99,12 +99,19 @@ function commandOf(req: ApprovalRequest): string | undefined {
 
 export class ApprovalChannel {
   private readonly pending = new Map<string, PendingApproval>();
+  private readonly manager: ApprovalChannelManagerLike;
+  private readonly sender: ApprovalChannelSenderLike;
+  private readonly logger: Logger;
 
   public constructor(
-    private readonly manager: ApprovalChannelManagerLike,
-    private readonly sender: ApprovalChannelSenderLike,
-    private readonly logger: Logger,
-  ) {}
+    manager: ApprovalChannelManagerLike,
+    sender: ApprovalChannelSenderLike,
+    logger: Logger,
+  ) {
+    this.manager = manager;
+    this.sender = sender;
+    this.logger = logger;
+  }
 
   /**
    * 注册 approval/request waterfall answerer。approval 服务未挂载时优雅禁用。

--- a/src/features/approval-renderer.ts
+++ b/src/features/approval-renderer.ts
@@ -4,8 +4,8 @@
  * 单次审批：一次只渲染一个审批请求（每个会话同时只有一个 pending 审批）。
  */
 import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
-import type { ApprovalRequest } from './approval-channel.js';
-import { encodeButtonData } from './button-utils.js';
+import type { ApprovalRequest } from './approval-channel.ts';
+import { encodeButtonData } from './button-utils.ts';
 
 /** 把审批请求渲染成 QQ 文本（含被 gate 的命令回显） */
 export function buildApprovalText(request: ApprovalRequest, command?: string): string {

--- a/src/features/question-channel.test.ts
+++ b/src/features/question-channel.test.ts
@@ -6,10 +6,10 @@ import {
   type UserQuestionRequest,
   type UserQuestionResult,
   type QuestionSessionRecordLike,
-} from './question-channel.js';
-import { buildKeyboard, formatQuestion } from './question-renderer.js';
-import { parseAnswer } from './answer-parser.js';
-import type { ChatScope, Logger, ReplyTarget } from '../types.js';
+} from './question-channel.ts';
+import { buildKeyboard, formatQuestion } from './question-renderer.ts';
+import { parseAnswer } from './answer-parser.ts';
+import type { ChatScope, Logger, ReplyTarget } from '../types.ts';
 
 function createLogger(): Logger {
   return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/src/features/question-channel.ts
+++ b/src/features/question-channel.ts
@@ -10,10 +10,10 @@
  *   - 完成 / 中断（abort / 超时 / 会话回收）：reject(ASK_ABORTED)
  */
 import type { InlineKeyboard, InteractionEvent } from '@tencent-connect/qqbot-nodejs';
-import type { ChatScope, Logger, ReplyTarget } from '../types.js';
-import { parseAnswer } from './answer-parser.js';
-import { buildKeyboard, formatQuestion } from './question-renderer.js';
-import { decodeButtonData } from './button-utils.js';
+import type { ChatScope, Logger, ReplyTarget } from '../types.ts';
+import { parseAnswer } from './answer-parser.ts';
+import { buildKeyboard, formatQuestion } from './question-renderer.ts';
+import { decodeButtonData } from './button-utils.ts';
 
 // ── 最小契约（对齐 dsh-user-questions，避免硬依赖） ──
 
@@ -79,11 +79,11 @@ export interface QuestionChannelConfigLike {
 const ASK_ABORTED = 'ASK_ABORTED';
 
 class QuestionChannelError extends Error {
-  public constructor(
-    message: string,
-    public readonly code: string,
-  ) {
+  public readonly code: string;
+
+  public constructor(message: string, code: string) {
     super(message);
+    this.code = code;
     this.name = 'QuestionChannelError';
   }
 }
@@ -107,13 +107,22 @@ export class QuestionChannel {
   private readonly pending = new Map<string, PendingEntry>();
   private uq?: UserQuestionsServiceLike;
   private origAsk?: UserQuestionsServiceLike['ask'];
+  private readonly manager: QuestionChannelManagerLike;
+  private readonly sender: QuestionChannelSenderLike;
+  private readonly config: QuestionChannelConfigLike;
+  private readonly logger: Logger;
 
   public constructor(
-    private readonly manager: QuestionChannelManagerLike,
-    private readonly sender: QuestionChannelSenderLike,
-    private readonly config: QuestionChannelConfigLike,
-    private readonly logger: Logger,
-  ) {}
+    manager: QuestionChannelManagerLike,
+    sender: QuestionChannelSenderLike,
+    config: QuestionChannelConfigLike,
+    logger: Logger,
+  ) {
+    this.manager = manager;
+    this.sender = sender;
+    this.config = config;
+    this.logger = logger;
+  }
 
   /**
    * 包装 userQuestions.ask：QQ 会话走 QQ 通道，其余委托原实现。

--- a/src/features/question-renderer.ts
+++ b/src/features/question-renderer.ts
@@ -4,8 +4,8 @@
  * 逐题渲染：一次只渲染一个问题（多题时由状态机逐题推进）。
  */
 import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
-import type { UserQuestion } from './question-channel.js';
-import { BUTTONS_PER_ROW, buttonLabel, encodeButtonData } from './button-utils.js';
+import type { UserQuestion } from './question-channel.ts';
+import { BUTTONS_PER_ROW, buttonLabel, encodeButtonData } from './button-utils.ts';
 
 /**
  * 为「单选、带选项」的问题构建内联键盘；不适用时返回 undefined。

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -7,20 +7,20 @@
 import type { Context } from '@deepseek-ai/cordis';
 import { QQBot } from '@tencent-connect/qqbot-nodejs';
 import type { InteractionEvent, MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
-import { SessionManager, type DshAgentRegistry } from '../session/index.js';
-import { handleInbound, createOutboundHandler } from '../transport/index.js';
-import type { ToolsRegistryLike } from '../transport/tool-presenter.js';
-import type { QQBotSender } from '../transport/outbound-buffer.js';
-import { QuestionChannel } from '../features/question-channel.js';
-import { ApprovalChannel, type ApprovalChannelContext } from '../features/approval-channel.js';
-import { decodeButtonData } from '../features/button-utils.js';
-import { buildUserAgent } from '../shared/index.js';
-import type { ImQQBotConfig } from '../config.js';
-import type { Logger } from '../types.js';
-import { setupMiddlewares } from './middleware-setup.js';
-import { startMediaCleanup } from '../media/media-cleaner.js';
-import { ensureVisionInputModal, registerDescribeImageTool } from '../media/vision-tool.js';
-import { registerSendFileTool } from '../media/send-file-tool.js';
+import { SessionManager, type DshAgentRegistry } from '../session/index.ts';
+import { handleInbound, createOutboundHandler } from '../transport/index.ts';
+import type { ToolsRegistryLike } from '../transport/tool-presenter.ts';
+import type { QQBotSender } from '../transport/outbound-buffer.ts';
+import { QuestionChannel } from '../features/question-channel.ts';
+import { ApprovalChannel, type ApprovalChannelContext } from '../features/approval-channel.ts';
+import { decodeButtonData } from '../features/button-utils.ts';
+import { buildUserAgent } from '../shared/index.ts';
+import type { ImQQBotConfig } from '../config.ts';
+import type { Logger } from '../types.ts';
+import { setupMiddlewares } from './middleware-setup.ts';
+import { startMediaCleanup } from '../media/media-cleaner.ts';
+import { ensureVisionInputModal, registerDescribeImageTool } from '../media/vision-tool.ts';
+import { registerSendFileTool } from '../media/send-file-tool.ts';
 
 /**
  * interaction 统一分发器：按 button_data 的顶层 `t` 判别字段，路由到对应

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,2 +1,2 @@
-export { setupMiddlewares } from './middleware-setup.js';
-export { bootstrapGateway } from './bootstrap.js';
+export { setupMiddlewares } from './middleware-setup.ts';
+export { bootstrapGateway } from './bootstrap.ts';

--- a/src/gateway/middleware-setup.ts
+++ b/src/gateway/middleware-setup.ts
@@ -19,13 +19,13 @@ import {
   historyBuffer,
   envelopeFormatter,
 } from '@tencent-connect/qqbot-nodejs';
-import type { ImQQBotConfig } from '../config.js';
-import type { SessionManager } from '../session/index.js';
-import type { Logger } from '../types.js';
-import { buildCommandList } from '../commands/index.js';
-import { attachmentProcessor } from '../middleware/attachment.js';
-import { questionAnswer } from '../middleware/question-answer.js';
-import { getHistoryStore, historyGroupKey } from '../features/history-store.js';
+import type { ImQQBotConfig } from '../config.ts';
+import type { SessionManager } from '../session/index.ts';
+import type { Logger } from '../types.ts';
+import { buildCommandList } from '../commands/index.ts';
+import { attachmentProcessor } from '../middleware/attachment.ts';
+import { questionAnswer } from '../middleware/question-answer.ts';
+import { getHistoryStore, historyGroupKey } from '../features/history-store.ts';
 
 export function setupMiddlewares(
   bot: QQBot,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,19 +5,19 @@
  * 网关组装（中间件编排 + 事件 + 出站 + 生命周期）见 src/gateway/。
  */
 import type { Context } from '@deepseek-ai/cordis';
-import { ConfigSchema, type ImQQBotConfig } from './config.js';
-import { bootstrapGateway } from './gateway/index.js';
-import type { DshAgentRegistry } from './session/index.js';
-import { getProfileDir, resolveEnv } from './shared/index.js';
-import { runQrSetup, persistCredentialsToProfile } from './setup.js';
-import type { Logger } from './types.js';
+import { ConfigSchema, type ImQQBotConfig } from './config.ts';
+import { bootstrapGateway } from './gateway/index.ts';
+import type { DshAgentRegistry } from './session/index.ts';
+import { getProfileDir, resolveEnv } from './shared/index.ts';
+import { runQrSetup, persistCredentialsToProfile } from './setup.ts';
+import type { Logger } from './types.ts';
 
 // ── Cordis 插件元数据 ──
 export const name = 'im-qqbot';
 export const inject = ['agents'];
 export const Config = ConfigSchema;
 
-export type { ImQQBotConfig } from './config.js';
+export type { ImQQBotConfig } from './config.ts';
 
 // ── 插件主体 ──
 export async function apply(ctx: Context, config: ImQQBotConfig): Promise<void> {

--- a/src/media/media-cleaner.ts
+++ b/src/media/media-cleaner.ts
@@ -9,7 +9,7 @@ import { readdir, rm, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { Context } from '@deepseek-ai/cordis';
-import type { Logger } from '../types.js';
+import type { Logger } from '../types.ts';
 
 /** 富媒体下载根目录（attachment.ts 复用） */
 export const MEDIA_ROOT = resolve(homedir(), '.dsh-qqbot', 'media');

--- a/src/media/send-file-tool.ts
+++ b/src/media/send-file-tool.ts
@@ -11,10 +11,10 @@ import { stat } from 'node:fs/promises';
 import { basename, isAbsolute, relative, resolve } from 'node:path';
 import type { Context } from '@deepseek-ai/cordis';
 import type { ContentBlock } from '@deepseek-ai/dsh-llm';
-import type { ImQQBotConfig, SendFileConfig } from '../config.js';
-import type { DshAgent, SessionManager } from '../session/index.js';
-import type { Logger, ReplyTarget } from '../types.js';
-import { MEDIA_ROOT } from './media-cleaner.js';
+import type { ImQQBotConfig, SendFileConfig } from '../config.ts';
+import type { DshAgent, SessionManager } from '../session/index.ts';
+import type { Logger, ReplyTarget } from '../types.ts';
+import { MEDIA_ROOT } from './media-cleaner.ts';
 
 /** 工具名（qqbot 前缀避免与其他通道的同名工具冲突） */
 export const SEND_FILE_TOOL_NAME = 'qqbot_send_file';

--- a/src/media/vision-tool.ts
+++ b/src/media/vision-tool.ts
@@ -22,8 +22,8 @@ import type {
   ImageBlock,
   StreamChunk,
 } from '@deepseek-ai/dsh-llm';
-import type { VisionConfig } from '../config.js';
-import type { Logger } from '../types.js';
+import type { VisionConfig } from '../config.ts';
+import type { Logger } from '../types.ts';
 
 /** 通过 dsh-llm 的 ImageBlock 间接引用 dsh-attachment 类型，避免直接依赖 dsh-attachment */
 type ImageAttachmentRef = ImageBlock['attachment'];

--- a/src/middleware/attachment.ts
+++ b/src/middleware/attachment.ts
@@ -5,9 +5,9 @@
  * 下载失败不阻断消息（记录告警后放行），确保附件异常不影响正常文本处理。
  */
 import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
-import { downloadMediaAttachments } from '../transport/attachment.js';
-import type { ImQQBotConfig } from '../config.js';
-import type { Logger, QuotedAttachment, RawAttachment } from '../types.js';
+import { downloadMediaAttachments } from '../transport/attachment.ts';
+import type { ImQQBotConfig } from '../config.ts';
+import type { Logger, QuotedAttachment, RawAttachment } from '../types.ts';
 
 export function attachmentProcessor(config: ImQQBotConfig, logger: Logger) {
   return async (ctx: MiddlewareContext, next: () => Promise<void>): Promise<void> => {

--- a/src/middleware/question-answer.ts
+++ b/src/middleware/question-answer.ts
@@ -5,7 +5,7 @@
  * 否则会被排队而无法到达 tryAnswer，导致「turn 等答案 ↔ 答案被缓冲」死锁。
  */
 import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
-import type { SessionManager } from '../session/index.js';
+import type { SessionManager } from '../session/index.ts';
 
 export function questionAnswer(manager: SessionManager) {
   return async (ctx: MiddlewareContext, next: () => Promise<void>): Promise<void> => {

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -3,7 +3,7 @@
  *
  * 统一的模型发现、路由解析、per-peer 偏好管理。
  */
-export { ModelResolver } from './model-resolver.js';
-export { PrefsStore } from './prefs-store.js';
-export { SettingsReader } from './settings-reader.js';
-export type { ModelRoute, ModelEntry } from './types.js';
+export { ModelResolver } from './model-resolver.ts';
+export { PrefsStore } from './prefs-store.ts';
+export { SettingsReader } from './settings-reader.ts';
+export type { ModelRoute, ModelEntry } from './types.ts';

--- a/src/model/model-resolver.ts
+++ b/src/model/model-resolver.ts
@@ -13,11 +13,11 @@
  *   > 宿主 agentDefaultModel 服务
  */
 import type { Context } from '@deepseek-ai/cordis';
-import type { ImQQBotConfig } from '../config.js';
-import type { Logger } from '../types.js';
-import type { ModelRoute, ModelEntry } from './types.js';
-import { PrefsStore } from './prefs-store.js';
-import { SettingsReader } from './settings-reader.js';
+import type { ImQQBotConfig } from '../config.ts';
+import type { Logger } from '../types.ts';
+import type { ModelRoute, ModelEntry } from './types.ts';
+import { PrefsStore } from './prefs-store.ts';
+import { SettingsReader } from './settings-reader.ts';
 
 /** ctx.llm 服务的最小接口（listProviders 同步，listModels 异步） */
 interface LlmServiceLike {
@@ -28,12 +28,18 @@ interface LlmServiceLike {
 export class ModelResolver {
   private readonly prefs: PrefsStore;
   private readonly settings: SettingsReader;
+  private readonly ctx: Context;
+  private readonly config: ImQQBotConfig;
+  private readonly logger?: Logger;
 
   constructor(
-    private readonly ctx: Context,
-    private readonly config: ImQQBotConfig,
-    private readonly logger?: Logger,
+    ctx: Context,
+    config: ImQQBotConfig,
+    logger?: Logger,
   ) {
+    this.ctx = ctx;
+    this.config = config;
+    this.logger = logger;
     this.prefs = new PrefsStore(
       config.debug ? (msg) => this.logger?.debug(msg) : undefined,
     );

--- a/src/model/prefs-store.ts
+++ b/src/model/prefs-store.ts
@@ -7,7 +7,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import type { ModelRoute } from './types.js';
+import type { ModelRoute } from './types.ts';
 
 /** 日志回调（可选） */
 type DebugFn = (msg: string) => void;

--- a/src/model/settings-reader.ts
+++ b/src/model/settings-reader.ts
@@ -8,7 +8,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { homedir } from 'node:os';
 import yaml from 'js-yaml';
-import type { ModelRoute, ModelEntry } from './types.js';
+import type { ModelRoute, ModelEntry } from './types.ts';
 
 /** settings.yaml 中的 provider 配置结构 */
 interface SettingsProviderConfig {

--- a/src/session/idle-evictor.ts
+++ b/src/session/idle-evictor.ts
@@ -3,16 +3,22 @@
  *
  * 定期检查会话最后活跃时间，超时则自动回收释放资源。
  */
-import type { SessionRecord } from './types.js';
+import type { SessionRecord } from './types.ts';
 
 export class IdleEvictor {
   private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly sessions: Map<string, SessionRecord>;
+  private readonly timeoutMs: number;
+  private readonly onEvict: (key: string, record: SessionRecord) => void;
 
   constructor(
-    private readonly sessions: Map<string, SessionRecord>,
-    private readonly timeoutMs: number,
-    private readonly onEvict: (key: string, record: SessionRecord) => void,
+    sessions: Map<string, SessionRecord>,
+    timeoutMs: number,
+    onEvict: (key: string, record: SessionRecord) => void,
   ) {
+    this.sessions = sessions;
+    this.timeoutMs = timeoutMs;
+    this.onEvict = onEvict;
     if (timeoutMs > 0) {
       this.timer = setInterval(() => this.check(), 60_000);
     }

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -3,8 +3,8 @@
  *
  * 管理 QQ peer → dsh Agent 的映射和生命周期。
  */
-export { SessionManager } from './session-manager.js';
-export { IdleEvictor } from './idle-evictor.js';
+export { SessionManager } from './session-manager.ts';
+export { IdleEvictor } from './idle-evictor.ts';
 export type {
   AgentSetup,
   SessionEventLike,
@@ -19,4 +19,4 @@ export type {
   SessionRecord,
   SessionStatus,
   TokenUsageStats,
-} from './types.js';
+} from './types.ts';

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -15,13 +15,13 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { SessionId } from '@deepseek-ai/dsh-session';
 import type { Context } from '@deepseek-ai/cordis';
-import type { ChatScope, Logger, ReplyTarget } from '../types.js';
-import type { ImQQBotConfig } from '../config.js';
-import { ModelResolver } from '../model/model-resolver.js';
-import type { ModelRoute, ModelEntry } from '../model/types.js';
-import { IdleEvictor } from './idle-evictor.js';
-import type { QuestionChannel } from '../features/question-channel.js';
-import type { ApprovalChannel } from '../features/approval-channel.js';
+import type { ChatScope, Logger, ReplyTarget } from '../types.ts';
+import type { ImQQBotConfig } from '../config.ts';
+import { ModelResolver } from '../model/model-resolver.ts';
+import type { ModelRoute, ModelEntry } from '../model/types.ts';
+import { IdleEvictor } from './idle-evictor.ts';
+import type { QuestionChannel } from '../features/question-channel.ts';
+import type { ApprovalChannel } from '../features/approval-channel.ts';
 import type {
   SessionEventLike,
   DshAgent,
@@ -37,7 +37,7 @@ import type {
   TokenUsageStats,
   CompactionServiceLike,
   CompactOutcome,
-} from './types.js';
+} from './types.ts';
 
 /** ManualCompactionError 各 code 的友好提示 */
 const COMPACTION_ERROR_HINTS: Record<string, string> = {
@@ -70,17 +70,25 @@ export class SessionManager {
   private sessions = new Map<string, SessionRecord>();
   private readonly evictor: IdleEvictor;
   private readonly modelResolver: ModelResolver;
+  private readonly ctx: Context;
+  private readonly agents: DshAgentRegistry;
+  private readonly config: ImQQBotConfig;
+  private readonly logger: Logger;
   /** 由 bootstrap 注入的问答通道（ask_user_question → QQ），会话回收时清理其待答问题 */
   public questionChannel?: QuestionChannel;
   /** 由 bootstrap 注入的审批通道（approval/request → QQ），会话回收时清理其待批审批 */
   public approvalChannel?: ApprovalChannel;
 
   constructor(
-    private readonly ctx: Context,
-    private readonly agents: DshAgentRegistry,
-    private readonly config: ImQQBotConfig,
-    private readonly logger: Logger,
+    ctx: Context,
+    agents: DshAgentRegistry,
+    config: ImQQBotConfig,
+    logger: Logger,
   ) {
+    this.ctx = ctx;
+    this.agents = agents;
+    this.config = config;
+    this.logger = logger;
     this.modelResolver = new ModelResolver(ctx, config, logger);
 
     this.evictor = new IdleEvictor(

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -2,7 +2,7 @@
  * 会话管理层类型定义
  */
 import type { Context } from '@deepseek-ai/cordis';
-import type { ChatScope, ReplyTarget } from '../types.js';
+import type { ChatScope, ReplyTarget } from '../types.ts';
 
 /** AgentSetup hook 类型 */
 export type AgentSetup = (agentCtx: Context) => Promise<void> | void;

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,6 +1,6 @@
 /**
  * 共享工具层
  */
-export { getProfileDir, resolveEnv, formatRelativeTime, buildUserAgent, PLUGIN_VERSION } from './utils.js';
-export { getScopePeer } from './scope.js';
-export { sendMarkdownChunked } from './send-helper.js';
+export { getProfileDir, resolveEnv, formatRelativeTime, buildUserAgent, PLUGIN_VERSION } from './utils.ts';
+export { getScopePeer } from './scope.ts';
+export { sendMarkdownChunked } from './send-helper.ts';

--- a/src/shared/send-helper.ts
+++ b/src/shared/send-helper.ts
@@ -4,7 +4,7 @@
  * 长内容自动按 QQ 消息限制切分后逐条发送。
  */
 import type { SlashCommandHandlerContext } from '@tencent-connect/qqbot-nodejs';
-import { chunkMarkdownText } from '../transport/chunker.js';
+import { chunkMarkdownText } from '../transport/chunker.ts';
 
 /**
  * 分块发送 markdown（长内容自动切分）

--- a/src/transport/attachment.ts
+++ b/src/transport/attachment.ts
@@ -10,9 +10,9 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { basename, extname, join, sep } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import * as dns from 'node:dns';
-import type { Logger, RawAttachment } from '../types.js';
-import type { MediaConfig } from '../config.js';
-import { MEDIA_ROOT } from '../media/media-cleaner.js';
+import type { Logger, RawAttachment } from '../types.ts';
+import type { MediaConfig } from '../config.ts';
+import { MEDIA_ROOT } from '../media/media-cleaner.ts';
 
 /** 默认富媒体下载大小上限（MB），可被 media.maxMB 覆盖 */
 const DEFAULT_MAX_MB = 200;

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -10,16 +10,16 @@
  */
 import type { ContentBlock } from '@deepseek-ai/dsh-llm';
 import { createUserMessage } from '@deepseek-ai/dsh-llm';
-import type { SessionManager } from '../session/index.js';
-import type { ImQQBotConfig } from '../config.js';
-import type { ChatScope, Logger, QuotedAttachment, RawAttachment, ReplyTarget } from '../types.js';
+import type { SessionManager } from '../session/index.ts';
+import type { ImQQBotConfig } from '../config.ts';
+import type { ChatScope, Logger, QuotedAttachment, RawAttachment, ReplyTarget } from '../types.ts';
 import {
   classifyContentType,
   isVoiceContentType,
   type DownloadedFile,
   type MediaKind,
-} from './attachment.js';
-import { clearGroupHistory } from '../features/history-store.js';
+} from './attachment.ts';
+import { clearGroupHistory } from '../features/history-store.ts';
 import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
 
 // ── 类型定义 ──

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -3,7 +3,7 @@
  *
  * 协议对接：QQ 消息入站 / 出站 / Markdown 切分。
  */
-export { handleInbound } from './inbound.js';
-export { createOutboundHandler } from './outbound.js';
-export { OutboundBuffer, type QQBotSender } from './outbound-buffer.js';
-export { chunkMarkdownText } from './chunker.js';
+export { handleInbound } from './inbound.ts';
+export { createOutboundHandler } from './outbound.ts';
+export { OutboundBuffer, type QQBotSender } from './outbound-buffer.ts';
+export { chunkMarkdownText } from './chunker.ts';

--- a/src/transport/outbound-buffer.test.ts
+++ b/src/transport/outbound-buffer.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { OutboundBuffer } from './outbound-buffer.js';
-import type { QQBotSender, StreamSessionLike } from './outbound-buffer.js';
-import type { SessionRecord } from '../session/index.js';
-import type { Logger, ReplyTarget } from '../types.js';
+import { OutboundBuffer } from './outbound-buffer.ts';
+import type { QQBotSender, StreamSessionLike } from './outbound-buffer.ts';
+import type { SessionRecord } from '../session/index.ts';
+import type { Logger, ReplyTarget } from '../types.ts';
 
 function createLogger(): Logger {
   return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/src/transport/outbound-buffer.ts
+++ b/src/transport/outbound-buffer.ts
@@ -5,10 +5,10 @@
  * 独立文件便于单测。
  */
 import type { InlineKeyboard } from '@tencent-connect/qqbot-nodejs';
-import type { SessionRecord } from '../session/index.js';
-import type { Logger, ReplyTarget } from '../types.js';
-import { chunkMarkdownText } from './chunker.js';
-import { StreamingWriter } from './streaming-writer.js';
+import type { SessionRecord } from '../session/index.ts';
+import type { Logger, ReplyTarget } from '../types.ts';
+import { chunkMarkdownText } from './chunker.ts';
+import { StreamingWriter } from './streaming-writer.ts';
 
 /** 流式输出节流间隔(ms)：连续 chunk 累积后停顿该间隔才推送 */
 const STREAM_THROTTLE_MS = 200;
@@ -29,14 +29,22 @@ export class OutboundBuffer {
   private buffer = '';
   private flushing = false;
   private readonly writer: StreamingWriter | null;
+  private readonly record: SessionRecord;
+  private readonly bot: QQBotSender;
+  private readonly limit: number;
+  private readonly logger: Logger;
 
   public constructor(
-    private readonly record: SessionRecord,
-    private readonly bot: QQBotSender,
-    private readonly limit: number,
-    private readonly logger: Logger,
+    record: SessionRecord,
+    bot: QQBotSender,
+    limit: number,
+    logger: Logger,
     streamingEnabled: boolean,
   ) {
+    this.record = record;
+    this.bot = bot;
+    this.limit = limit;
+    this.logger = logger;
     this.writer = streamingEnabled
       ? new StreamingWriter({ bot, target: record.replyTarget, logger, throttleMs: STREAM_THROTTLE_MS })
       : null;

--- a/src/transport/outbound.ts
+++ b/src/transport/outbound.ts
@@ -4,12 +4,12 @@
  * 采用路由器模式：OutboundRouter 持有会话级状态（文本缓冲、工具调用记录），
  * 事件解析归一化在 events.ts，路由按事件类型分发到私有方法。
  */
-import type { SessionManager, SessionRecord } from '../session/index.js';
-import type { ImQQBotConfig } from '../config.js';
-import type { Logger } from '../types.js';
-import { chunkMarkdownText } from './chunker.js';
-import { OutboundBuffer, type QQBotSender } from './outbound-buffer.js';
-import { formatToolResult, type ToolsRegistryLike, type ToolResultData } from './tool-presenter.js';
+import type { SessionManager, SessionRecord } from '../session/index.ts';
+import type { ImQQBotConfig } from '../config.ts';
+import type { Logger } from '../types.ts';
+import { chunkMarkdownText } from './chunker.ts';
+import { OutboundBuffer, type QQBotSender } from './outbound-buffer.ts';
+import { formatToolResult, type ToolsRegistryLike, type ToolResultData } from './tool-presenter.ts';
 import {
   parseEvent,
   extractTurnError,
@@ -19,10 +19,10 @@ import {
   type ToolResultEvent,
   type TurnEndEvent,
   type RawSessionEvent,
-} from './events.js';
+} from './events.ts';
 
-export type { QQBotSender } from './outbound-buffer.js';
-export type { ToolsRegistryLike } from './tool-presenter.js';
+export type { QQBotSender } from './outbound-buffer.ts';
+export type { ToolsRegistryLike } from './tool-presenter.ts';
 
 /** 出站处理器签名（注册到 ctx.on('session/event')） */
 export type OutboundHandler = (session: SessionLike, event: RawSessionEvent) => void;
@@ -47,14 +47,25 @@ const SILENT_TURN_ERROR_CODES = new Set(['STREAM_CLOSED']);
 class OutboundRouter {
   private readonly buffers = new Map<string, OutboundBuffer>();
   private readonly toolCalls = new Map<string, ToolCallRecord>();
+  private readonly manager: SessionManager;
+  private readonly bot: QQBotSender;
+  private readonly config: ImQQBotConfig;
+  private readonly logger: Logger;
+  private readonly toolsRegistry: ToolsRegistryLike | undefined;
 
   public constructor(
-    private readonly manager: SessionManager,
-    private readonly bot: QQBotSender,
-    private readonly config: ImQQBotConfig,
-    private readonly logger: Logger,
-    private readonly toolsRegistry: ToolsRegistryLike | undefined,
-  ) {}
+    manager: SessionManager,
+    bot: QQBotSender,
+    config: ImQQBotConfig,
+    logger: Logger,
+    toolsRegistry: ToolsRegistryLike | undefined,
+  ) {
+    this.manager = manager;
+    this.bot = bot;
+    this.config = config;
+    this.logger = logger;
+    this.toolsRegistry = toolsRegistry;
+  }
 
   /** 事件分发入口 */
   public route(session: SessionLike, raw: RawSessionEvent): void {

--- a/src/transport/streaming-writer.test.ts
+++ b/src/transport/streaming-writer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { StreamingWriter } from './streaming-writer.js';
-import type { QQBotSender, StreamSessionLike } from './outbound-buffer.js';
-import type { Logger, ReplyTarget } from '../types.js';
+import { StreamingWriter } from './streaming-writer.ts';
+import type { QQBotSender, StreamSessionLike } from './outbound-buffer.ts';
+import type { Logger, ReplyTarget } from '../types.ts';
 
 function createLogger(): Logger {
   return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/src/transport/streaming-writer.ts
+++ b/src/transport/streaming-writer.ts
@@ -9,8 +9,8 @@
  *   - 终态幂等（finished）：finish/abort 后忽略 append，重复 finish 不重复 complete
  *   - 中止关闭（abort）：abort 时若 session 已打开，串行 complete 关闭，避免悬挂
  */
-import type { Logger, ReplyTarget } from '../types.js';
-import type { QQBotSender, StreamSessionLike } from './outbound-buffer.js';
+import type { Logger, ReplyTarget } from '../types.ts';
+import type { QQBotSender, StreamSessionLike } from './outbound-buffer.ts';
 
 export interface StreamingWriterDeps {
   bot: QQBotSender;
@@ -30,7 +30,11 @@ export class StreamingWriter {
   private throttleTimer: ReturnType<typeof setTimeout> | null = null;
   private chain: Promise<void> = Promise.resolve();
 
-  public constructor(private readonly deps: StreamingWriterDeps) {}
+  private readonly deps: StreamingWriterDeps;
+
+  public constructor(deps: StreamingWriterDeps) {
+    this.deps = deps;
+  }
 
   /** 是否应降级为静态发送：从未成功发送过任何分片 */
   public get shouldFallback(): boolean {

--- a/src/types-augment.d.ts
+++ b/src/types-augment.d.ts
@@ -9,7 +9,7 @@
  * - downloadedQuoteFiles: attachmentProcessor 中间件 → 下载到本地的引用消息附件
  */
 import '@tencent-connect/qqbot-nodejs';
-import type { DownloadedFile } from './transport/attachment.js';
+import type { DownloadedFile } from './transport/attachment.ts';
 
 declare module '@tencent-connect/qqbot-nodejs' {
   interface MiddlewareState {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "lib": ["ES2022"],
     "types": ["node"],
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

Mechanical refactor with no behaviour change: switch all relative imports to `.ts` extensions (backed by TS 5.7 `allowImportingTsExtensions` + `rewriteRelativeImportExtensions`) and replace constructor parameter properties with explicit class-field declarations.

## Changes

### 1. `.ts` import extensions

- All relative imports across `src/` changed from `./foo.js` to `./foo.ts`.
- `tsconfig.json` adds:
  - `"allowImportingTsExtensions": true`
  - `"rewriteRelativeImportExtensions": true` — the compiler rewrites `.ts` back to `.js` in emitted output, so runtime resolution is unchanged.

### 2. Explicit class-field declarations

- Replaced `constructor(private readonly dep: Dep)` parameter properties with explicit `private readonly` / `public readonly` field declarations and assignment in the constructor body.
- Aligns with the TS style rule of member ordering (`field` before `constructor`) and keeps field visibility explicit.