### PR TITLE
feat(commands): /sendfile 发送本地文件到私聊（SDK sendFile 桥接，v1 c2c ≤20MB）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
+## [Unreleased]
+
+### 新功能
+
+- **发送文件**：新增 `/sendfile <文件绝对路径>` 指令，机器人把服务器本地文件（PDF、图片、视频等，≤20MB）直接发到当前私聊，走 SDK `sendFile`（上传 + `msg_type=7`，5–20MB 自动分片）。v1 仅私聊、仅本地绝对路径；群聊、URL 源、主动 push 后续开放。
+
 ## [0.4.0] - 2026-08-16
 
 ### 新功能

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 | `/bot-ping` | 连通性测试 |
 | `/bot-version` | 查看版本信息 |
 | `/bot-status` | 查看当前会话状态 |
+| `/sendfile <绝对路径>` | 发送服务器本地文件到当前私聊（≤20MB，仅私聊；含空格路径加引号） |
 | `/bot-help` | 查看所有指令 |
 
 ## 核心模块

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ import { presetCommand } from './preset.ts';
 import { statusCommand } from './status.ts';
 import { helpCommand } from './help.ts';
 import { pingCommand, versionCommand, stopCommand } from './misc.ts';
+import { sendFileCommand } from './send-file.ts';
 
 /**
  * 构建标准命令列表
@@ -30,6 +31,7 @@ export function buildCommandList(deps: CommandDeps): CategorizedCommand[] {
     pingCommand(),
     versionCommand(deps),
     statusCommand(deps),
+    sendFileCommand(),
   ];
 
   // help 需要访问完整列表（含自身），通过闭包惰性引用

--- a/src/commands/send-file.test.ts
+++ b/src/commands/send-file.test.ts
@@ -1,0 +1,139 @@
+/**
+ * /sendfile 命令单测
+ *
+ * 覆盖：参数校验 / 群聊门禁 / 大小上限 / 引号剥离 / SDK 桥接参数透传 / 失败语义。
+ * bot.sendFile 用 spy 桩，不触真实网络。
+ */
+import { describe, it, expect, afterAll } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sendFileCommand } from './send-file.ts';
+
+const workspace = mkdtempSync(join(tmpdir(), 'send-file-test-'));
+
+function tempFile(name: string, bytes?: number, sparse = false): string {
+  const path = join(workspace, name);
+  if (bytes === undefined) {
+    writeFileSync(path, 'hello');
+  } else if (sparse) {
+    // 稀疏文件：声明长度但几乎不占磁盘，秒建
+    writeFileSync(path, '');
+    truncateSync(path, bytes);
+  } else {
+    writeFileSync(path, Buffer.alloc(bytes, 1));
+  }
+  return path;
+}
+
+function makeCtx(opts: {
+  raw?: string;
+  kind?: 'c2c' | 'group';
+  sendFile?: (...args: unknown[]) => Promise<unknown>;
+} = {}) {
+  const calls: unknown[][] = [];
+  const scope = opts.kind ?? 'c2c';
+  const replyTarget = { scope, targetId: scope === 'group' ? 'group-1' : 'user-1', msgId: 'msg-1' };
+  const ctx = {
+    command: { name: 'sendfile', args: [], raw: opts.raw ?? '' },
+    message: { kind: scope, senderId: 'user-1' },
+    replyTarget,
+    bot: {
+      sendFile:
+        opts.sendFile ??
+        (async (...args: unknown[]) => {
+          calls.push(args);
+          return { upload: { file_uuid: 'u1' }, message: { id: 'm2' } };
+        }),
+    },
+  };
+  return { ctx, calls, replyTarget };
+}
+
+function run(ctx: unknown): Promise<string> {
+  return sendFileCommand().handler(ctx as never) as Promise<string>;
+}
+
+afterAll(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+describe('/sendfile', () => {
+  it('无参数 → 用法提示', async () => {
+    const { ctx, calls } = makeCtx({ raw: '' });
+    expect(await run(ctx)).toContain('用法');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('群聊 → 明确拒绝（v1 仅私聊），不触发送', async () => {
+    const { ctx, calls } = makeCtx({ raw: 'C:\\any.pdf', kind: 'group' });
+    expect(await run(ctx)).toContain('群聊暂不开放');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('相对路径 → 要求绝对路径', async () => {
+    const { ctx } = makeCtx({ raw: 'some/relative.pdf' });
+    expect(await run(ctx)).toContain('绝对路径');
+  });
+
+  it('文件不存在 → 报错含路径', async () => {
+    const missing = join(workspace, 'nope.pdf');
+    const { ctx } = makeCtx({ raw: missing });
+    expect(await run(ctx)).toContain('文件不存在');
+  });
+
+  it('空文件 → 拒发', async () => {
+    const empty = tempFile('empty.bin', 0);
+    const { ctx } = makeCtx({ raw: empty });
+    expect(await run(ctx)).toContain('空文件');
+  });
+
+  it('目录 → 非文件拒绝', async () => {
+    const { ctx } = makeCtx({ raw: workspace });
+    expect(await run(ctx)).toContain('路径不是文件');
+  });
+
+  it('超过 20MB 上限 → 友好拒绝并报当前大小', async () => {
+    const big = tempFile('big.pdf', 21 * 1024 * 1024, true);
+    expect(statSync(big).size).toBe(21 * 1024 * 1024);
+    const { ctx, calls } = makeCtx({ raw: big });
+    const reply = await run(ctx);
+    expect(reply).toContain('超过');
+    expect(reply).toContain('20.0 MB');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('成功路径 → 桥接参数逐字透传 + 确认消息', async () => {
+    const file = tempFile('report.pdf');
+    const { ctx, calls, replyTarget } = makeCtx({ raw: file });
+    const reply = await run(ctx);
+    expect(reply).toContain('已发送');
+    expect(reply).toContain('report.pdf');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([replyTarget, { localPath: file }, { fileName: 'report.pdf' }]);
+  });
+
+  it('引号包裹的含空格路径 → 剥引号后正常发送', async () => {
+    const file = tempFile('my paper.pdf');
+    const { ctx, calls } = makeCtx({ raw: `"${file}"` });
+    expect(await run(ctx)).toContain('已发送');
+    expect(calls[0]?.[1]).toEqual({ localPath: file });
+  });
+
+  it('SDK 抛错 → 发送失败语义（markdown 报错不静默）', async () => {
+    const file = tempFile('ok.pdf');
+    const { ctx } = makeCtx({
+      raw: file,
+      sendFile: async () => {
+        throw new Error('media upload rejected: 429');
+      },
+    });
+    const reply = await run(ctx);
+    expect(reply).toContain('发送失败');
+    expect(reply).toContain('429');
+  });
+
+  it('临时工作区可用（测试自检）', () => {
+    expect(existsSync(workspace)).toBe(true);
+  });
+});

--- a/src/commands/send-file.ts
+++ b/src/commands/send-file.ts
@@ -1,0 +1,87 @@
+/**
+ * /sendfile <绝对路径> — 发送本地文件到当前私聊（v1 仅 c2c）
+ *
+ * 调用链：QQBot.sendFile → uploadMedia(base64 单发 <5MB / chunked ≥5MB)
+ * → sendMediaMessage(msg_type=7)。被动上下文（replyTarget 带 msgId），
+ * 不受主动 push 频控限制。
+ *
+ * 上限 v1 保守取 20MB（SDK base64 单传硬上限对齐值）；localPath 源
+ * 5–100MB 分片链路 SDK 已具备，放宽与否留给配置项（D5）后续决定。
+ *
+ * 与 qqbot_send_file 工具的分工：工具 = 模型主动发文件（按扩展名分发
+ * 图片/视频/语音/文件 + 路径白名单 + 被动三级兜底）；本命令 = 用户主动
+ * 快速通道，直接把服务器上的文件推给自己，无需模型参与。
+ *
+ * ⚠ 安全边界：本命令等价于「按路径读本地文件」原语。斜杠命令对可达
+ * 用户默认开放（access.c2cMode=open 时任何能私聊机器人的人可用），
+ * 部署方应通过 slashCommand.allowFrom 收紧白名单；上游合并前需在
+ * README 显著提示。
+ */
+import { existsSync, statSync } from 'node:fs';
+import { basename, isAbsolute } from 'node:path';
+import type { CategorizedCommand } from './types.ts';
+
+/** 与 SDK file-utils MAX_UPLOAD_SIZE 对齐的 v1 上限（20MB） */
+const MAX_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024;
+
+function formatSize(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  return mb >= 1 ? `${mb.toFixed(1)} MB` : `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}
+
+/** 去掉参数外层引号（支持含空格路径） */
+function unwrapQuotes(raw: string): string {
+  const m = /^"([^"]*)"$|^'([^']*)'$/.exec(raw);
+  return m ? (m[1] ?? m[2] ?? '') : raw;
+}
+
+export function sendFileCommand(): CategorizedCommand {
+  return {
+    name: 'sendfile',
+    category: 'qqbot',
+    description: '发送本地文件到当前私聊（≤20MB）',
+    usage: '/sendfile <文件绝对路径>',
+    handler: async (cmdCtx) => {
+      const path = unwrapQuotes(cmdCtx.command.raw.trim());
+
+      if (cmdCtx.message.kind === 'group') {
+        return '群聊暂不开放文件发送（v1 仅私聊）';
+      }
+      if (!path) {
+        return '用法: /sendfile <文件绝对路径>（含空格请加引号）';
+      }
+      if (!isAbsolute(path)) {
+        return '请提供文件的绝对路径';
+      }
+      if (!existsSync(path)) {
+        return `文件不存在: ${path}`;
+      }
+
+      let size: number;
+      try {
+        const st = statSync(path);
+        if (!st.isFile()) {
+          return '路径不是文件（目录/设备不支持发送）';
+        }
+        if (st.size === 0) {
+          return '空文件不发送';
+        }
+        size = st.size;
+      } catch (error) {
+        return `无法读取文件: ${error instanceof Error ? error.message : String(error)}`;
+      }
+
+      if (size > MAX_UPLOAD_SIZE_BYTES) {
+        return `文件超过 ${formatSize(MAX_UPLOAD_SIZE_BYTES)} 上限（当前 ${formatSize(size)}）`;
+      }
+
+      const fileName = basename(path);
+      try {
+        await cmdCtx.bot.sendFile(cmdCtx.replyTarget, { localPath: path }, { fileName });
+      } catch (error) {
+        return `发送失败: ${error instanceof Error ? error.message : String(error)}`;
+      }
+      return `已发送 📎 ${fileName}（${formatSize(size)}）`;
+    },
+  };
+}

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -96,6 +96,9 @@ export async function bootstrapGateway(
         msgId: target.msgId as string,
       },
     }),
+    // 文件桥接：与 mediaSender（qqbot_send_file 工具）同走被动三级兜底；
+    // allowEvent=false —— SDK 文件发送不支持 event_id（见 reply-target.ts）
+    sendFile: (target, source, opts) => bot.sendFile(resolveReplyTarget(target, replyLimiter, false), source, opts),
   };
 
   const outboundHandler = createOutboundHandler(manager, sender, config, logger, toolsRegistry);

--- a/src/transport/outbound-buffer.test.ts
+++ b/src/transport/outbound-buffer.test.ts
@@ -16,6 +16,7 @@ function createBot(openStreamImpl?: () => StreamSessionLike): QQBotSender {
   return {
     sendMarkdown: vi.fn().mockResolvedValue(undefined),
     openStream: vi.fn(openStreamImpl ?? (() => createSession())),
+    sendFile: vi.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/src/transport/outbound-buffer.ts
+++ b/src/transport/outbound-buffer.ts
@@ -19,10 +19,26 @@ export interface StreamSessionLike {
   complete(): Promise<unknown>;
 }
 
+/** 文件来源（与 SDK QQBot.sendFile 三形态对齐；斜杠命令与未来工具用 localPath） */
+export interface FileSendSource {
+  localPath?: string;
+  buffer?: Buffer;
+  url?: string;
+}
+
+/** 文件发送选项（SDK opts 子集；onProgress 分片进度回调） */
+export interface FileSendOptions {
+  fileName?: string;
+  content?: string;
+  onProgress?: (uploaded: number, total: number) => void;
+}
+
 /** QQ Bot 发送接口 */
 export interface QQBotSender {
   sendMarkdown(target: ReplyTarget, content: string, opts?: { keyboard?: InlineKeyboard }): Promise<unknown>;
   openStream(target: ReplyTarget): StreamSessionLike;
+  /** 上传 + 发送通用文件（msg_type=7）；SDK 按大小自动选择单发（<5MB）或分片（≥5MB） */
+  sendFile(target: ReplyTarget, source: FileSendSource, opts?: FileSendOptions): Promise<unknown>;
 }
 
 export class OutboundBuffer {

--- a/src/transport/streaming-writer.test.ts
+++ b/src/transport/streaming-writer.test.ts
@@ -15,6 +15,7 @@ function createBot(openStreamImpl?: () => StreamSessionLike): QQBotSender {
   return {
     sendMarkdown: vi.fn().mockResolvedValue(undefined),
     openStream: vi.fn(openStreamImpl ?? (() => createSession())),
+    sendFile: vi.fn().mockResolvedValue(undefined),
   };
 }
 


### PR DESCRIPTION
## 背景

用户需求：把「机器人发文件到 QQ」补齐到**用户主动**触发面。现状核对（基于 7bac0a9）：

- ✅ `qqbot_send_file` 工具（模型主动发文件）已存在：按扩展名分发 image/video/voice/file + 路径白名单 + 被动三级兜底；
- ❌ **slash 命令面仍无入口**——用户在 QQ 里想直接拿服务器上的文件（不经模型）无路可走；
- ❌ `QQBotSender`（出站文本路径抽象）没有 `sendFile`，出站自动转发（如 PR-3 场景）无桥可用。

本 PR 补这两块，与官方工具**互补不重复**。

## 内容

- `src/commands/send-file.ts`：新增 `/sendfile <文件绝对路径>`，复用现有命令框架注册进 `buildCommandList`；
- `src/transport/outbound-buffer.ts`：`QQBotSender` 新增 `sendFile(target, source, opts)`，`FileSendSource`/`FileSendOptions` 与 SDK 三形态（`localPath/buffer/url`）对齐；
- `src/gateway/bootstrap.ts`：sender 适配器的 `sendFile` 与官方 `mediaSender` 同走 `resolveReplyTarget(target, replyLimiter, false)`（`allowEvent=false`：SDK 文件发送不支持 event_id，遵循 `reply-target.ts` 的既有约定）。

## 行为与边界

| 点 | v1 决策 |
|---|---|
| 触发 | 仅 slash 命令。上下文自带新鲜 `msgId`，天然被动回复，不受主动 push 频控 |
| 来源 | 仅本地绝对路径（URL/buffer 留给后续） |
| 作用域 | 仅 c2c。群聊明确回复"群聊暂不开放（v1 仅私聊）"而非静默透传（SDK `scope:'c2c'` 对不匹配消息是放行到普通消息流，行为不可预期，故在 handler 内做门禁） |
| 上限 | 20MB 硬编码（对齐 SDK base64 单传上限的保守值）。官方工具的 `sendFile.restrictPaths/extraRoots` 配置面是更好的方向，但 slash 命令与工具的信任模型不同（命令=用户直接下指令，工具=模型经白名单），v1 先保守 |
| 失败语义 | 不存在/目录/空文件/超限/SDK 抛错 → 均回复 markdown，不抛到中间件 |
| 含空格路径 | 支持外层引号 |

## ⚠ 安全提示（希望维护者评估）

`/sendfile` 等价于「按任意路径读本地文件」原语。默认 `access.c2cMode: open` 时任何能私聊机器人的用户可用（可读取如 `cordis.patch.yml` 的凭据文件）。建议：部署方用 `slashCommand.allowFrom` 收紧；若认为必要，可在后续迭代给命令也接上 `sendFile.restrictPaths` 同源白名单（改动量很小）。

## 测试

- `tsc --noEmit` 干净；`vitest run` **76/76**（上游既有 65 + 新增 11）。
- 新增 `src/commands/send-file.test.ts` 11 例：用法/群聊门禁/相对路径/不存在/空文件/目录/21MB 稀疏文件拒绝/成功桥接（`toEqual` 逐字断言透传给 `bot.sendFile` 的参数）/引号剥离/SDK 抛错语义。
- 既有 `outbound-buffer.test.ts`、`streaming-writer.test.ts` 的 `QQBotSender` fake 补 `sendFile` 桩。
- 实测：SDK `sendFile` 直发 c2c 5 个 PDF（含 1.26MB 论文）全部成功；文件消息权限已开通。

## 与其它 PR 的关系

与 #21/#22/#23/#30/#31 无代码文件交集（仅 CHANGELOG/README 行级相邻）。本分支已 rebase 到 7bac0a9 并适配 `.ts` 导入扩展与被动回复重构。
