### PR TITLE
feat(session): QQ 渠道自声明 —— source.channel 戳 + qqChannel 会话投影单元

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
+## [Unreleased]
+
+### 新功能
+
+- **QQ 渠道自声明**：入站消息在 `source` 携带 `channel`（`qq/c2c` / `qq/group`），并注册 `qqChannel` 会话投影单元（官方扩展面，零宿主改动）。渠道值随投影帧到达会话列表，供第三方渠道视图（dsh-channel-view 等）直接分组；重放安全、冷会话可读。对应 RFC-0001（session header `channel` 字段）落地前的过渡实现。
+
 ## [0.4.0] - 2026-08-16
 
 ### 新功能

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type { Context } from '@deepseek-ai/cordis';
 import { ConfigSchema, type ImQQBotConfig } from './config.ts';
 import { bootstrapGateway } from './gateway/index.ts';
 import type { DshAgentRegistry } from './session/index.ts';
+import { registerQqChannelProjection } from './session/index.ts';
 import { getProfileDir, resolveEnv } from './shared/index.ts';
 import { runQrSetup, persistCredentialsToProfile } from './setup.ts';
 import type { Logger } from './types.ts';
@@ -57,6 +58,17 @@ export async function apply(ctx: Context, config: ImQQBotConfig): Promise<void> 
   }
 
   const resolvedConfig: ImQQBotConfig = { ...config, appId, appSecret };
+
+  // ── QQ 渠道自声明（qqChannel 投影单元）──
+  // 经条件注入挂载：sessionProjections 服务缺席（老宿主组装）时静默跳过，
+  // 不影响插件其余功能。值随官方 session/projection 帧到达会话列表行，
+  // 供渠道视图类插件（如 dsh-channel-view）消费。
+  (ctx as unknown as {
+    inject(deps: string[], cb: (scoped: unknown) => void): void;
+  }).inject(['sessionProjections'], (scopedCtx) => {
+    registerQqChannelProjection(scopedCtx);
+    logger.info('qqChannel projection unit registered');
+  });
 
   await bootstrapGateway(ctx, agents, resolvedConfig, logger);
 }

--- a/src/session/channel-declaration.ts
+++ b/src/session/channel-declaration.ts
@@ -1,0 +1,83 @@
+/**
+ * QQ 渠道自声明 —— `qqChannel` 会话投影单元。
+ *
+ * 宿主 `MessageSourceMap` 在类型层明确标注为 merge-extensible sum type
+ * （"plugins add their own `kind`s"），持久化与 `session/event` 推送帧对
+ * `source` 的校验均为 looseObject（额外字段直通）。入站消息据此携带
+ * `source.channel`（'qq/c2c' / 'qq/group'），本单元在日志折叠时对该声明
+ * 做一次性锁存——输入是会话日志本身：重放安全，随投影 checkpoint 落盘，
+ * 冷会话经 cachedSnapshot 依然可读。
+ *
+ * 与 RFC-0001（deepseek-ai/deepseek-harness discussion #3897）的关系：
+ * 该 RFC 提议渠道进入 session header（"创建即知、永不变化"的属性应随
+ * 列表行直发而非投影折叠）。本单元是 header 落地前的过渡实现，语义完全
+ * 一致（首条消息即定渠道），对消费方（如 dsh-channel-view）透明可替换。
+ *
+ * 注册形态参照 @deepseek-ai/dsh-tool-todo 的 todos 单元官方姿势；
+ * schema 用鸭子类型，零运行时依赖（注册表只在边界消费 `parse`）。
+ */
+
+/** 渠道值域。`'unobserved'` 是状态机初始态，永不作为线上值下发。 */
+export type QqChannelState = 'unobserved' | 'qq/c2c' | 'qq/group';
+
+/** 折叠所需的最小事件形状（结构收窄，不依赖宿主事件类型版本）。 */
+interface ProjectionLogEvent {
+  type?: unknown;
+  data?: { source?: { kind?: unknown; channel?: unknown } };
+}
+
+/** 字符串值 schema（鸭子类型；注册表只在边界调用 parse）。 */
+const stringSchema = {
+  parse: (value: unknown): string => {
+    if (typeof value !== 'string') {
+      throw new TypeError(`[im-qqbot] qqChannel projection value must be a string, got ${typeof value}`);
+    }
+    return value;
+  },
+};
+
+/**
+ * 由会话 scope 得出要打进 `source.channel` 的声明值。
+ * @param scope - QQ 会话范围（私聊 / 群聊）。
+ * @returns 渠道值（'qq/c2c' | 'qq/group'）。
+ */
+export function qqChannelOf(scope: 'c2c' | 'group'): Exclude<QqChannelState, 'unobserved'> {
+  return scope === 'group' ? 'qq/group' : 'qq/c2c';
+}
+
+/** 注册入口所需的最小服务面（结构性声明，避免绑定宿主类型版本）。 */
+interface QqChannelRegistrationHost {
+  sessionProjections?: {
+    register(definition: unknown): () => void;
+  };
+}
+
+/**
+ * 在携带 sessionProjections 服务的上下文上注册 qqChannel 单元。
+ * 服务缺席（如极老宿主）时静默降级为空句柄，不影响插件其余功能。
+ * @param ctx - 已注入 sessionProjections 的 cordis 上下文（或等价结构）。
+ * @returns 单元反注册句柄。
+ */
+export function registerQqChannelProjection(ctx: QqChannelRegistrationHost | unknown): () => void {
+  const registry = (ctx as QqChannelRegistrationHost | null | undefined)?.sessionProjections;
+  if (registry === undefined || typeof registry.register !== 'function') {
+    return () => {};
+  }
+  return registry.register({
+    key: 'qqChannel',
+    stateSchema: stringSchema,
+    init: (): QqChannelState => 'unobserved',
+    apply: (state: QqChannelState, event: ProjectionLogEvent): QqChannelState => {
+      if (state !== 'unobserved') return state;
+      if (event?.type !== 'user/message') return state;
+      const channel = event.data?.source?.channel;
+      return channel === 'qq/c2c' || channel === 'qq/group' ? channel : state;
+    },
+    stateVersion: 1,
+    // wire 在场 = 值随快照/推送帧下发客户端；view 恒等。
+    wire: {
+      viewSchema: stringSchema,
+      view: (state: QqChannelState) => state,
+    },
+  });
+}

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -5,6 +5,11 @@
  */
 export { SessionManager } from './session-manager.ts';
 export { IdleEvictor } from './idle-evictor.ts';
+export {
+  qqChannelOf,
+  registerQqChannelProjection,
+  type QqChannelState,
+} from './channel-declaration.ts';
 export type {
   AgentSetup,
   SessionEventLike,

--- a/src/transport/inbound.ts
+++ b/src/transport/inbound.ts
@@ -20,6 +20,7 @@ import {
   type MediaKind,
 } from './attachment.ts';
 import { clearGroupHistory } from '../features/history-store.ts';
+import { qqChannelOf } from '../session/channel-declaration.ts';
 import type { MiddlewareContext } from '@tencent-connect/qqbot-nodejs';
 
 // ── 类型定义 ──
@@ -131,7 +132,9 @@ export async function handleInbound(
 
   const message = createUserMessage({
     content,
-    source: { kind: 'user' as const },
+    // channel 为 im-qqbot 的渠道自声明字段：宿主 source 校验为 looseObject
+    // （持久化与推送帧均直通），qqChannel 投影单元凭它锁存真实渠道。
+    source: { kind: 'user' as const, channel: qqChannelOf(scope) },
   });
 
   record.agent.followup(message);


### PR DESCRIPTION
## 背景

跟进 deepseek-harness discussion #3897 / RFC-0001 叙事与 dsh-channel-view 演示：上游承诺"把 QQ 渠道接成真实渠道声明（qq/c2c、qq/group），替换演示 latch 值"。本 PR 即该承诺的**源端**。

## 机制（零宿主改动）

侦察发现宿主消息溯源面就是官方扩展点，注释原文：

> `MessageSourceMap` — **Merge-extensible sum type — plugins add their own `kind`s**（`@deepseek-ai/dsh-llm` message.d.ts）

且持久化与 `session/event` 帧的 source 校验均为 `looseObject({kind})`，额外字段直通。于是：

1. **入站声明**（`transport/inbound.ts`）：`createUserMessage` 的 source 加 `channel: 'qq/c2c' | 'qq/group'`（`createUserMessage` 泛型透传字面量类型，无 cast）。
2. **投影单元**（新文件 `session/channel-declaration.ts` + `index.ts` 条件注入注册）：`qqChannel` 单元在日志折叠时锁存 `user/message` 事件里的 `source.channel`——
   - 重放安全：输入是会话日志本身；
   - 冷会话可读：随投影 checkpoint 落盘，重启后 `cachedSnapshot` 直读；
   - `ctx.inject(['sessionProjections'], …)` 缺席即静默降级，不破坏老宿主组装。
3. 消费端（dsh-channel-view v2.3，另一仓）把 `qqChannel` 置于渠道分组最高优先级，演示 latch 退居兜底——承诺闭环。

## 与 RFC-0001 的关系

RFC 主张"创建即知、永不变化"的属性应进 session header。本单元是 header 落地前的**同语义过渡**（首条消息即定渠道），对消费方透明：header 上线后可无痛替换为直接读 `header.channel`。

## 验证

- `npm run build`（tsc）通过；单元折叠逻辑 node 冒烟通过（stamped 事件锁存、无关事件透传）。
- 本地 profile 安装已打同构 dist 补丁（NOTES + 原件备份随包存档）；宿主重启后经 QQ 私聊/群聊消息实测 `projectionValues.qqChannel` 行为，结果将回帖更新本节。

Ref: deepseek-ai/deepseek-harness discussion #3897（RFC-0001）
