### PR TITLE
feat(config): 一个 dsh 绑定多个 QQ Bot（bots[] 配置 + per-appId 状态命名空间）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
+## [Unreleased]
+
+### 新功能
+
+- **一个 dsh 绑定多个 QQ Bot（草案）**：新增 `bots: [{appId, appSecret}, …]` 配置数组，与 legacy 单字段并存（合并去重、legacy 在前）。单条目行为与历史完全一致；≥2 条目时每 bot 独立 gateway/SessionManager 实例，per-peer 偏好文件按 `~/.dsh-qqbot/bots/<appId>/` 命名空间隔离（单 bot 沿用旧共享路径，存量零迁移），工具/视觉/媒体清理等进程级注册仅首位实例执行。已知限制见 README「多 Bot」节。
+
 ## [0.4.0] - 2026-08-16
 
 ### 新功能

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 |------|------|--------|------|
 | `appId` | string | **必填** | QQ Bot AppID（或通过 `QQBOT_APPID` 环境变量） |
 | `appSecret` | string | **必填** | QQ Bot AppSecret（或通过 `QQBOT_SECRET` 环境变量） |
+| `bots` | array | `[]` | 多 Bot 列表 `[{appId, appSecret}, …]`，与上方单字段并存时自动合并去重；总数 ≥2 进入多实例模式（见下节） |
 | `provider` | string | `deepseek-official` | LLM 提供商名称 |
 | `model` | string | `deepseek-chat` | 模型名称 |
 | `preset` | string | - | Agent preset id |
@@ -90,6 +91,23 @@ npx @deepseek-ai/dsh web --patch /path/to/dsh-qqbot/cordis.dev.yml
 | `sessionIdleTimeout` | number | `1800000` | 会话闲置超时(ms)，默认 30 分钟 |
 | `askTimeoutMs` | number | `300000` | 待答问题超时(ms)，默认 5 分钟（ask_user_question） |
 | `debug` | boolean | `false` | 调试模式 |
+
+## 多 Bot（一个 dsh 同时服务多个 QQ Bot）
+
+```yaml
+im-qqbot:
+  bots:
+    - appId: "100000001"
+      appSecret: "…"   # 正式号
+    - appId: "100000002"
+      appSecret: "…"   # 测试号
+```
+
+- 每个 bot 一个独立网关连接与会话管理器实例；会话键本就含 appId（`qqbot:<appId>:<scope>:<peerId>`），跨 bot 会话天然隔离。
+- **per-peer 模型/preset 偏好按实例命名空间**：多 bot 时落 `~/.dsh-qqbot/bots/<appId>/model-prefs.json`；单 bot（含仅 legacy 字段）沿用 `~/.dsh-qqbot/model-prefs.json`，存量数据零迁移。
+- 出站/问答/审批对宿主事件流的订阅是全局的，但各实例先做 `findBySessionId` 归属判定——只有持有该会话的实例处理，双实例不会双发。
+- 进程级注册（`qqbot_describe_image` / `qqbot_send_file` 工具、视觉 modal、媒体清理）仅**首位实例**执行。
+- 已知限制：① 非凭据类配置（prompt/白名单/模型默认等）当前全 bot 共享，per-bot 覆盖待后续；② `qqbot_send_file` 出站绑定首位实例，其他 bot 会话调用会经首位发送；③ msgId 缓存键未含 appId（QQ 平台 openid per-app 隔离，实际不冲突，属防御性 TODO）；④ 扫码绑定仅覆盖首位/legacy 槽；⑤ 每 bot 的网关连接数受官方 per-app 上限约束。
 
 ## 内置命令
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,16 @@ export interface ImQQBotConfig {
   appId: string;
   /** QQ Bot AppSecret */
   appSecret: string;
+  /**
+   * 多 bot 列表。与上方单字段并存：resolveBotIdentities 合并两者
+   * （legacy 在前），去重后 ≥2 即进入多实例模式（per-appId 状态命名空间）。
+   */
+  bots?: BotIdentity[];
+  // ── 运行时字段（由入口按实例注入；不在配置 schema 面）──
+  /** 同进程 ≥2 实例：状态文件走 ~/.dsh-qqbot/bots/<appId>/ 命名空间 */
+  multiBot?: boolean;
+  /** 本实例是否首位：工具/视觉/清理等进程级全局注册仅 primary 执行 */
+  primaryBot?: boolean;
   /** dsh LLM 提供商名称 */
   provider?: string;
   /** 模型名称 */
@@ -97,6 +107,10 @@ export interface ImQQBotConfig {
 export const ConfigSchema: Schema<ImQQBotConfig> = Schema.object({
   appId: Schema.string().default('').description('QQ Bot AppID'),
   appSecret: Schema.string().default('').description('QQ Bot AppSecret'),
+  bots: Schema.array(Schema.object({
+    appId: Schema.string().description('QQ Bot AppID'),
+    appSecret: Schema.string().description('QQ Bot AppSecret'),
+  })).default([]).description('多 bot 列表（与单字段并存；≥2 生效时按 appId 隔离状态）'),
   provider: Schema.string().description('LLM provider name'),
   model: Schema.string().description('Model name'),
   preset: Schema.string().description('Agent preset id'),
@@ -158,3 +172,26 @@ export const ConfigSchema: Schema<ImQQBotConfig> = Schema.object({
     extraRoots: [],
   }).description('附件发送工具配置'),
 });
+
+/** Bot 凭据对（多 bot 列表条目；亦是 legacy 单字段的等价抽象）。 */
+export interface BotIdentity {
+  readonly appId: string;
+  readonly appSecret: string;
+}
+
+/**
+ * 合并配置面为生效 bot 列表：legacy 单字段在前（向后兼容），bots[] 追加；
+ * 按 appId 去重，凭据不全的条目丢弃。返回空数组 = 无任何可启动 bot。
+ */
+export function resolveBotIdentities(config: ImQQBotConfig): BotIdentity[] {
+  const out: BotIdentity[] = [];
+  const seen = new Set<string>();
+  const push = (appId?: string, appSecret?: string): void => {
+    if (!appId || !appSecret || seen.has(appId)) return;
+    seen.add(appId);
+    out.push({ appId, appSecret });
+  };
+  push(config.appId, config.appSecret);
+  for (const bot of config.bots ?? []) push(bot?.appId, bot?.appSecret);
+  return out;
+}

--- a/src/gateway/bootstrap.ts
+++ b/src/gateway/bootstrap.ts
@@ -20,6 +20,8 @@ import { decodeButtonData } from '../features/button-utils.ts';
 import { buildUserAgent } from '../shared/index.ts';
 import type { ImQQBotConfig } from '../config.ts';
 import type { ChatScope, Logger } from '../types.ts';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import { setupMiddlewares } from './middleware-setup.ts';
 import { startMediaCleanup } from '../media/media-cleaner.ts';
 import { ensureVisionInputModal, registerDescribeImageTool } from '../media/vision-tool.ts';
@@ -46,7 +48,14 @@ export async function bootstrapGateway(
   config: ImQQBotConfig,
   logger: Logger,
 ): Promise<void> {
-  const manager = new SessionManager(ctx, agents, config, logger);
+  // 多 bot 模式：本实例状态文件命名空间（单 bot 为 undefined → 落 legacy 共享路径，
+  // 存量用户数据零迁移）。sessionKey/历史缓存本就带 appId，唯一共享可变资源是
+  // prefs 文件，命名空间化后"实例持有该会话"的判定（manager.findBySessionId +
+  // 各自 prefs）即天然完成全局事件流的归属过滤。
+  const stateDir = config.multiBot === true
+    ? resolve(homedir(), '.dsh-qqbot', 'bots', config.appId)
+    : undefined;
+  const manager = new SessionManager(ctx, agents, config, logger, stateDir);
 
   // ── 初始化 QQ Bot SDK ──
   const userAgent = buildUserAgent();
@@ -132,25 +141,32 @@ export async function bootstrapGateway(
     console.log(`[im-qqbot] Bot ready! appId=${config.appId}`);
   });
 
-  // ── 富媒体过期清理 ──
-  if (config.media.enabled) {
-    startMediaCleanup(ctx, config.media.ttlHours, logger);
+  // ── 进程级全局注册（媒体清理 / 视觉 modal / 工具）：仅 primary 实例执行 ──
+  // 这些注册共享同一宿主注册表，多实例重复注册会撞名；媒体目录与视觉描述与
+  // bot 身份无关，一份足矣。已知限制：qqbot_send_file 绑定 primary 的 sender，
+  // 多 bot 下其他 bot 会话调用会经 primary 出站（正确路由需 per-session 实例
+  // 注册表，见 PR body TODO）。
+  if (config.primaryBot !== false) {
+    // ── 富媒体过期清理 ──
+    if (config.media.enabled) {
+      startMediaCleanup(ctx, config.media.ttlHours, logger);
+    }
+
+    // ── 视觉工具注册（qqbot_describe_image，复用 dsh llm + attachments） ──
+    ensureVisionInputModal(config.vision, logger);
+    registerDescribeImageTool(ctx, config.vision, logger);
+
+    // ── 附件发送工具注册（qqbot_send_file） ──
+    // 包装 bot：让文件发送也走 msgId 兜底 + 被动回复限额管控。
+    // 注意：SDK 文件发送暂不支持 event_id，故 allowEvent=false，跳过 event 候选。
+    const mediaSender: MediaSenderLike = {
+      sendImage: (target, source) => bot.sendImage(resolveReplyTarget(target, replyLimiter, false), source),
+      sendVideo: (target, source) => bot.sendVideo(resolveReplyTarget(target, replyLimiter, false), source),
+      sendVoice: (target, source) => bot.sendVoice(resolveReplyTarget(target, replyLimiter, false), source),
+      sendFile: (target, source, opts) => bot.sendFile(resolveReplyTarget(target, replyLimiter, false), source, opts),
+    };
+    registerSendFileTool(ctx, mediaSender, manager, config, logger);
   }
-
-  // ── 视觉工具注册（qqbot_describe_image，复用 dsh llm + attachments） ──
-  ensureVisionInputModal(config.vision, logger);
-  registerDescribeImageTool(ctx, config.vision, logger);
-
-  // ── 附件发送工具注册（qqbot_send_file） ──
-  // 包装 bot：让文件发送也走 msgId 兜底 + 被动回复限额管控。
-  // 注意：SDK 文件发送暂不支持 event_id，故 allowEvent=false，跳过 event 候选。
-  const mediaSender: MediaSenderLike = {
-    sendImage: (target, source) => bot.sendImage(resolveReplyTarget(target, replyLimiter, false), source),
-    sendVideo: (target, source) => bot.sendVideo(resolveReplyTarget(target, replyLimiter, false), source),
-    sendVoice: (target, source) => bot.sendVoice(resolveReplyTarget(target, replyLimiter, false), source),
-    sendFile: (target, source, opts) => bot.sendFile(resolveReplyTarget(target, replyLimiter, false), source, opts),
-  };
-  registerSendFileTool(ctx, mediaSender, manager, config, logger);
 
   // ── 生命周期 ──
   (ctx as unknown as { effect(fn: () => (() => Promise<void>) | void, name?: string): void })
@@ -165,5 +181,5 @@ export async function bootstrapGateway(
         await manager.disposeAll();
         bot.stop();
       };
-    }, 'im-qqbot.lifecycle');
+    }, `im-qqbot.lifecycle:${config.appId}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * 网关组装（中间件编排 + 事件 + 出站 + 生命周期）见 src/gateway/。
  */
 import type { Context } from '@deepseek-ai/cordis';
-import { ConfigSchema, type ImQQBotConfig } from './config.ts';
+import { ConfigSchema, resolveBotIdentities, type ImQQBotConfig } from './config.ts';
 import { bootstrapGateway } from './gateway/index.ts';
 import type { DshAgentRegistry } from './session/index.ts';
 import { getProfileDir, resolveEnv } from './shared/index.ts';
@@ -29,8 +29,8 @@ export async function apply(ctx: Context, config: ImQQBotConfig): Promise<void> 
   let appId = resolveEnv(config.appId, 'QQBOT_APPID');
   let appSecret = resolveEnv(config.appSecret, 'QQBOT_SECRET');
 
-  // ── 凭据缺失时唤起扫码绑定 ──
-  if (!appId || !appSecret) {
+  // ── 凭据缺失时唤起扫码绑定（bots[] 已有凭据则不触发） ──
+  if ((!appId || !appSecret) && (config.bots ?? []).length === 0) {
     logger.info('凭据未配置，尝试扫码绑定...');
     const credentials = await runQrSetup();
 
@@ -58,5 +58,24 @@ export async function apply(ctx: Context, config: ImQQBotConfig): Promise<void> 
 
   const resolvedConfig: ImQQBotConfig = { ...config, appId, appSecret };
 
-  await bootstrapGateway(ctx, agents, resolvedConfig, logger);
+  // ── 多 bot 装配：legacy 单字段在前，bots[] 追加（去重）──
+  // 单条目时行为与历史完全一致（无命名空间、primary 全局注册）；
+  // ≥2 时进入多实例模式：per-appId 状态命名空间 + 全局注册仅首位执行。
+  const identities = resolveBotIdentities(resolvedConfig);
+  if (identities.length === 0) {
+    logger.error('无可用的 QQ Bot 凭据（appId/appSecret 或 bots[]），插件未启动');
+    return;
+  }
+  if (identities.length > 1) {
+    logger.info(`multi-bot mode: launching ${identities.length} bots (${identities.map((b) => b.appId).join(', ')})`);
+  }
+  for (const [i, bot] of identities.entries()) {
+    await bootstrapGateway(ctx, agents, {
+      ...resolvedConfig,
+      appId: bot.appId,
+      appSecret: bot.appSecret,
+      multiBot: identities.length > 1,
+      primaryBot: i === 0,
+    }, logger);
+  }
 }

--- a/src/model/model-resolver.ts
+++ b/src/model/model-resolver.ts
@@ -36,12 +36,14 @@ export class ModelResolver {
     ctx: Context,
     config: ImQQBotConfig,
     logger?: Logger,
+    stateDir?: string,
   ) {
     this.ctx = ctx;
     this.config = config;
     this.logger = logger;
     this.prefs = new PrefsStore(
       config.debug ? (msg) => this.logger?.debug(msg) : undefined,
+      stateDir,
     );
     this.settings = new SettingsReader();
   }

--- a/src/model/prefs-store.ts
+++ b/src/model/prefs-store.ts
@@ -32,8 +32,9 @@ export class PrefsStore {
   private readonly prefsPath: string;
   private readonly debugLog?: DebugFn;
 
-  constructor(debugLog?: DebugFn) {
-    this.prefsPath = resolve(homedir(), '.dsh-qqbot', 'model-prefs.json');
+  constructor(debugLog?: DebugFn, stateDir?: string) {
+    // 单 bot：legacy 共享路径原样（存量零迁移）；多 bot：入口传 per-appId 命名空间。
+    this.prefsPath = resolve(stateDir ?? resolve(homedir(), '.dsh-qqbot'), 'model-prefs.json');
     this.debugLog = debugLog;
     this.load();
   }

--- a/src/session/session-manager.ts
+++ b/src/session/session-manager.ts
@@ -84,12 +84,13 @@ export class SessionManager {
     agents: DshAgentRegistry,
     config: ImQQBotConfig,
     logger: Logger,
+    stateDir?: string,
   ) {
     this.ctx = ctx;
     this.agents = agents;
     this.config = config;
     this.logger = logger;
-    this.modelResolver = new ModelResolver(ctx, config, logger);
+    this.modelResolver = new ModelResolver(ctx, config, logger, stateDir);
 
     this.evictor = new IdleEvictor(
       this.sessions,


### PR DESCRIPTION
## 目标

一个 dsh 进程同时服务多个 QQ Bot（正式号 + 测试号同驻、多渠道号治理）。回答的架构问题："dsh 绑定多个 qqbot" 当前的堵点全在插件的四处单实例假设（配置槽、prefs 共享文件、全局注册的撞名、QR env 回落），本 PR 逐收口。

## 实现（代码完整，tsc 通过——不是纸面草案）

**配置面**（`config.ts`）：新增 `bots: [{appId, appSecret}]`，与 legacy 单字段并存。`resolveBotIdentities()` 合并两者：legacy 在前 → bots[] 追加，按 appId 去重、凭据不全的条目丢弃。冒烟验证三种形态（dedup / legacy-only / filter）行为正确。

**装配**（`index.ts`）：按身份列表循环 `bootstrapGateway`，每实例注入 `multiBot`/`primaryBot` 运行时字段。**单条目时走完全相同的历史路径（无命名空间、primary 全局注册）——对存量用户零变化**。扫码绑定仅在"legacy 与 bots[] 都无凭据"时触发。

**存储隔离**（`bootstrap.ts` → `SessionManager`/`ModelResolver`/`PrefsStore` 加可选 `stateDir`）：多 bot 时 per-peer 偏好落 `~/.dsh-qqbot/bots/<appId>/model-prefs.json`；单 bot 沿用旧共享路径，**存量零迁移**。

**为什么存储隔离就够了**（关键机制）：出站/问答/审批虽然都订阅宿主全局事件流，但入口第一动作都是 `manager.findBySessionId(...)` 归属判定、查不到即 return——session 对象本来就只存在于持有它的实例。此前真正会串台的只有共享 prefs 文件（`sessionIds` 映射会把另一实例的会话误认领），命名空间化后归属链闭环。sessionKey（`qqbot:<appId>:<scope>:<peerId>`）与派生 sessionId 本就带 appId 命名空间；history-store 键含 appId。

**进程级注册**：`qqbot_describe_image` / `qqbot_send_file` 工具、视觉 modal、媒体清理仅 primary 执行（宿主注册表共享，重复注册撞名）；lifecycle effect 名带 appId。

## 已知限制（故标 draft）

1. **非凭据配置全 bot 共享**：prompt / access 白名单 / 模型默认等目前对所有实例一致。白名单（openid per-app 隔离）共享实际无意义——`bots[]` 条目应支持 per-bot override（spread 语义），涉及 config schema 深合并，想先听维护者取向；
2. `qqbot_send_file` 绑定 primary 实例 sender：非 primary 会话调用会经 primary 出站（QQ API 层会因跨 app openid 拒绝，表现为错误而非错发，但正确做法是 per-session 实例路由表）；
3. msgid-cache 键无 appId 维度（openid 实际 per-app 隔离，防御性收口）；
4. QR 扫码只写 legacy 槽（多 bot 需手工配 `bots[]`）；
5. 每 bot 网关连接数受 QQ 官方 per-app 上限约束（平台侧，不是本 PR 能解决的）；
6. **未做双 bot 实链路联调**（无第二个真实 bot 在手；单 bot 回归路径 = 现有代码逐行同构）。

与 #39（qqChannel 声明）在 `index.ts` apply 尾部有数行交叠：两个都合的话以先到者为基，后者 rebase（冲突面极小）。

## Stage 拆分（如果你想小步合）

- **Stage-1（无行为变化、可立即合）**：`stateDir` 参数链（PrefsStore/ModelResolver/SessionManager）、`resolveBotIdentities` 解析层、primary-gate 全局注册、effect 名带 appId——单 bot 下逐条与现状等价；
- **Stage-2（本体）**：index.ts 按身份循环装配。

需要我拆成两个 PR 就说一声；当前按一个 PR 提交、commit 内不分叉。

## 验证

- `npm run build`（tsc strict + noUncheckedIndexedAccess）通过；
- `resolveBotIdentities` node 冒烟：dedup `["111","222"]`、legacy `["999"]`、filter `["444"]` 全部符合预期；
- 单 bot 回归：`multiBot` 未设 → stateDir undefined → prefs 路径与 effect 名行为与 HEAD 一致。
