### PR TITLE
fix(prefs): model-prefs.json 原子写入 + 损坏文件隔离取证（附 5 例单测）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)。
 
+## [Unreleased]
+
+### 修复
+
+- **偏好持久化健壮性**：`model-prefs.json` 写入改为原子（tmp + rename），进程在写入瞬间被中断不再产生半截 JSON；若既有文件已损坏（历史中断产物/手工编辑出错），加载时自动改名为 `.corrupt-<时间戳>` 保留取证后以空偏好继续——旧实现仅 debug 模式有一行日志，损坏事故静默无迹。构造支持注入 filePath（单测与后续多实例命名空间复用）。
+
 ## [0.4.0] - 2026-08-16
 
 ### 新功能

--- a/src/model/prefs-store.test.ts
+++ b/src/model/prefs-store.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync, writeFileSync, existsSync, readdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PrefsStore } from './prefs-store.ts';
+
+const dirs: string[] = [];
+
+function tmpPath(name = 'model-prefs.json'): string {
+  const dir = mkdtempSync(join(tmpdir(), 'qqbot-prefs-'));
+  dirs.push(dir);
+  return join(dir, name);
+}
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('prefs-store 持久化', () => {
+  it('写入-重载 round-trip（三类映射都恢复）', () => {
+    const path = tmpPath();
+    const a = new PrefsStore(undefined, path);
+    a.setOverride('k1', { provider: 'pi-ai', model: 'm1' });
+    a.setSessionId('k1', 'session-abc');
+    a.setPreset('k1', 'preset-x');
+
+    const b = new PrefsStore(undefined, path);
+    expect(b.getOverride('k1')).toEqual({ provider: 'pi-ai', model: 'm1' });
+    expect(b.getSessionId('k1')).toBe('session-abc');
+    expect(b.getPreset('k1')).toBe('preset-x');
+  });
+
+  it('落盘文件是完整 JSON，且不留下 .tmp 残留', () => {
+    const path = tmpPath();
+    const store = new PrefsStore(undefined, path);
+    store.setSessionId('k2', 'session-def');
+
+    expect(() => JSON.parse(readFileSync(path, 'utf8'))).not.toThrow();
+    expect(existsSync(`${path}.tmp`)).toBe(false);
+  });
+
+  it('损坏文件被隔离为 .corrupt-*，原路径释放，以空偏好继续', () => {
+    const path = tmpPath();
+    writeFileSync(path, '{"overrides": {"k1": ', 'utf8'); // 半截 JSON（模拟写中断产物）
+
+    const store = new PrefsStore(undefined, path);
+    expect(store.getOverride('k1')).toBeUndefined();
+
+    const dir = path.slice(0, path.lastIndexOf('/') >= 0 ? path.lastIndexOf('/') : path.lastIndexOf('\\'));
+    const quarantined = readdirSync(dir).filter((f) => f.includes('.corrupt-'));
+    expect(quarantined).toHaveLength(1);
+    // 取证：隔离文件保留原始坏内容
+    expect(readFileSync(join(dir, quarantined[0]!), 'utf8')).toBe('{"overrides": {"k1": ');
+  });
+
+  it('隔离后再次写入能在新建文件上正常 round-trip', () => {
+    const path = tmpPath();
+    writeFileSync(path, 'not json at all', 'utf8');
+    const store = new PrefsStore(undefined, path);
+    store.setOverride('k9', { provider: 'p', model: 'm' });
+
+    const reloaded = new PrefsStore(undefined, path);
+    expect(reloaded.getOverride('k9')).toEqual({ provider: 'p', model: 'm' });
+  });
+
+  it('空文件（0 字节）同样走隔离路径而非抛错', () => {
+    const path = tmpPath();
+    writeFileSync(path, '', 'utf8');
+    const store = new PrefsStore(undefined, path);
+    expect(store.hasOverride('anything')).toBe(false);
+    const dir = path.slice(0, path.lastIndexOf('/') >= 0 ? path.lastIndexOf('/') : path.lastIndexOf('\\'));
+    expect(readdirSync(dir).some((f) => f.includes('.corrupt-'))).toBe(true);
+  });
+});

--- a/src/model/prefs-store.ts
+++ b/src/model/prefs-store.ts
@@ -1,10 +1,15 @@
 /**
  * PrefsStore — per-peer 会话偏好持久化（模型 + preset）
  *
- * 隔离文件 I/O 操作，便于单元测试时 mock。
- * 存储路径：~/.dsh-qqbot/model-prefs.json
+ * 隔离文件 I/O 操作，构造时可注入 filePath（单测/多实例命名空间）。
+ * 默认存储路径：~/.dsh-qqbot/model-prefs.json
+ *
+ * 持久化保证：
+ * - 写入原子（tmp + rename）：进程中断不再产生半截 JSON 覆盖旧数据；
+ * - 读取容错但留痕：文件解析失败时改名为 `.corrupt-<ts>` 保留取证
+ *   （旧实现只在 debug 模式打一行日志，损坏事故静默无迹），随后以空偏好继续。
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import type { ModelRoute } from './types.ts';
@@ -32,8 +37,8 @@ export class PrefsStore {
   private readonly prefsPath: string;
   private readonly debugLog?: DebugFn;
 
-  constructor(debugLog?: DebugFn) {
-    this.prefsPath = resolve(homedir(), '.dsh-qqbot', 'model-prefs.json');
+  constructor(debugLog?: DebugFn, filePath?: string) {
+    this.prefsPath = filePath ?? resolve(homedir(), '.dsh-qqbot', 'model-prefs.json');
     this.debugLog = debugLog;
     this.load();
   }
@@ -99,7 +104,8 @@ export class PrefsStore {
     try {
       if (!existsSync(this.prefsPath)) return;
       const content = readFileSync(this.prefsPath, 'utf8');
-      const data = JSON.parse(content) as PrefsFile;
+      const data = this.parseOrQuarantine(content);
+      if (!data) return;
       if (data.overrides && typeof data.overrides === 'object') {
         for (const [key, route] of Object.entries(data.overrides)) {
           if (route.provider && route.model) {
@@ -126,7 +132,24 @@ export class PrefsStore {
     }
   }
 
+  /** JSON 解析失败 → 损坏文件改名隔离保留取证，返回 undefined（调用方以空偏好继续）。 */
+  private parseOrQuarantine(content: string): PrefsFile | undefined {
+    try {
+      return JSON.parse(content) as PrefsFile;
+    } catch (err) {
+      const quarantine = `${this.prefsPath}.corrupt-${Date.now()}`;
+      try {
+        renameSync(this.prefsPath, quarantine);
+        this.debugLog?.(`loadPrefs: 文件损坏已隔离到 ${quarantine}（原因：${err instanceof Error ? err.message : String(err)}）`);
+      } catch {
+        this.debugLog?.(`loadPrefs failed（隔离亦失败）: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      return undefined;
+    }
+  }
+
   private write(): void {
+    const tmp = `${this.prefsPath}.tmp`;
     try {
       mkdirSync(dirname(this.prefsPath), { recursive: true });
       const data: PrefsFile = {
@@ -134,8 +157,14 @@ export class PrefsStore {
         sessionIds: Object.fromEntries(this.sessionIds.entries()),
         presets: Object.fromEntries(this.presets.entries()),
       };
-      writeFileSync(this.prefsPath, JSON.stringify(data, null, 2), 'utf8');
+      // 原子写：先落 tmp 再 rename 覆盖目标，rename 在同卷上是原子的，
+      // 任何时刻目标路径上的文件要么是完整旧版本、要么是完整新版本。
+      writeFileSync(tmp, JSON.stringify(data, null, 2), 'utf8');
+      renameSync(tmp, this.prefsPath);
     } catch (err) {
+      try {
+        unlinkSync(tmp);
+      } catch { /* tmp 可能不存在，忽略 */ }
       this.debugLog?.(`writePrefs failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }


### PR DESCRIPTION
## 问题

`model-prefs.json` 存 per-peer 模型/preset 偏好 + `sessionKey→sessionId` 映射（重启后恢复 fork 会话靠它）。现状两处薄弱：

1. **写入非原子**：`writeFileSync` 就地全量覆盖。写盘瞬间进程被 kill（热更新竞态、系统休眠、蓝屏）→ 留下半截 JSON；
2. **损坏静默无痕**：下次 `load()` 的 catch 只在 `config.debug` 时打一行日志，然后以空偏好继续——用户视角就是"所有 peer 的模型选择莫名全部重置"，且坏文件已被下次 write 覆盖，**无法事后取证**。

## 改动

- `write()`：先写 `<path>.tmp` 再 `renameSync` 原子替换（同卷 rename 原子性由 OS 保证，Windows 为 `MoveFileEx(REPLACE_EXISTENT)`，Node 层语义一致）；异常路径清理 tmp 残留；
- `load()`：解析失败 → 损坏文件改名 `model-prefs.json.corrupt-<ts>` 保留取证，空偏好继续。隔离动作本身经 debugLog 上报路径；
- `constructor(debugLog?, filePath?)`：路径注入（默认值不变，存量行为零影响）。与 `PeerMap` 既有的 `filePath ??` 注入约定同构；本 PR 内调用点不传参，为单测与后续多实例状态命名空间（#40 Stage-1）铺路。

## 验证

- 新增 `src/model/prefs-store.test.ts` 5 例：三类映射 round-trip / 落盘完整 JSON 且无 `.tmp` 残留 / 损坏隔离且坏内容原样保留在 `.corrupt-*` / 隔离后重建可正常 round-trip / 0 字节文件走隔离不抛错；
- 全量 `npm test`：**8 files, 70 tests passed**（含既有 65 例回归）；`tsc` strict 通过。

## 兼容性

默认路径、调用签名（新增参数全可选）、数据格式均不变。已有损坏文件（历史上被静默吞掉的）首次加载时被隔离成 `.corrupt-*` 并自然重置——这正是期望行为：坏数据不再既丢偏好又占着路径。
