### PR TITLE
docs(readme): ERESOLVE 安装冲突的排障提示与已实测的绕过命令（#37）

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ npx @deepseek-ai/dsh --profile qqbot
 
 > **提示**：建议升级至 `0.4.0` 以上版本扫码，支持点击链接在浏览器打开，避免部分终端二维码渲染错位的问题。
 
+> **安装报 `ERESOLVE could not resolve`？** 已知冲突（[#37](https://github.com/tencent-connect/dsh-qqbot/issues/37) 跟踪中）：`@deepseek-ai/dsh-tools` 等包仍处于 prerelease（`-rc`）peer 版本线，npm 7+ 的严格 peer 解析会拒绝与之相交的组合，与插件本身无关。实测可绕过（仅安装期解析策略，不改运行行为）：跳过 `plugin add`，直接对 profile 目录安装——
+> ```bash
+> npm install --prefix ~/.dsh/profiles/qqbot --legacy-peer-deps @tencent-connect/dsh-qqbot
+> ```
+> 安装完成后按原方式启动即可。
+
 ### 方式二：本地路径安装
 
 ```bash


### PR DESCRIPTION
## 问题

#37（未关闭）：profile 安装（`dsh plugin add` 或直接 `npm install`）会报 `ERESOLVE could not resolve`——`@deepseek-ai/dsh-tools` 等包仍处于 prerelease（`-rc`）peer 版本线，npm 7+ 严格解析拒绝与之不相交的组合。这是**首次安装用户必踩**的坑（本次以真实 profile 依赖树复现：`Found: @deepseek-ai/dsh-agent@0.1.1-rc.2 … Could not resolve`），而根治要等版本线收敛，#37 尚 open——README 安装节目前对此零提示。

## 改动

纯文档：安装节补一段排障提示——症状识别（ERESOLVE）、根因归属（#37，非插件问题）、绕过命令、影响面说明（`--legacy-peer-deps` 仅安装期解析策略，不改运行行为）。

## 验证

绕过命令不是推测：以本机真实 profile 的依赖树（含 `@tencent-connect/dsh-qqbot@^0.4.0`）做最小复现目录，`npm install --dry-run` 复现 ERESOLVE，追加 `--legacy-peer-deps` 后 **exit 0**（完整解析通过）。

## 说明

- 若 `plugin add` 后续支持透传 npm 参数，此段可简化为一行 flag；当前 CLI 无该通道，故给出直接 `npm install` 的等价步骤（README 方式一本就是"手动执行"风格，一致）。
- #37 根治合入后建议删除本段（已标注"跟踪中"）。
